### PR TITLE
TIQR-262: Add support for new HTTPS format URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,16 @@ To use SURF library in your project:
 ```
 4. Override resources, styles, strings and MainActivity (if needed)
 
+5. Set the gradle.properties
+
+The following properties are supported (see the gradle.properties in this repository for example values):
+* `schemeEnroll`: The enrollment URL should start with this HTTP scheme
+* `schemeAuth`: The authentication URL should start with this HTTP scheme
+* `pathParamEnroll`: You can also use HTTPS URLs for enrollment. In that case, this enrollment URL should start with this path parameter 
+* `pathParamAuth`: You can also use HTTPS URLs for authentication. In that case, this authentication URL should start with this path parameter.
+* `enforceChallengeHost`: Optional parameter. When set, the app will check if the HTTP URL has this domain (or a subdomain of it) set as the host. 
+* `tokenExchangeEnabled`: If the token exchange feature is enabled. When set to false, the FCM token will not be converted, but sent directly to the server.
+
 # Making changes in library
 
 1. Make changes in the code

--- a/data/build.gradle.kts
+++ b/data/build.gradle.kts
@@ -39,6 +39,21 @@ android {
 
         buildConfigField(
             "String",
+            "ENFORCE_CHALLENGE_HOST",
+            "\"${project.property("enforceChallengeHost")}\""
+        )
+        buildConfigField(
+            "String",
+            "TIQR_ENROLL_PATH_PARAM",
+            "\"${project.property("pathParamEnroll")}\""
+        )
+        buildConfigField(
+            "String",
+            "TIQR_AUTH_PATH_PARAM",
+            "\"${project.property("pathParamAuth")}\""
+        )
+        buildConfigField(
+            "String",
             "TIQR_ENROLL_SCHEME",
             "\"${project.property("schemeEnroll") as String}://\""
         )

--- a/data/src/main/java/org/tiqr/data/model/AuthenticationUrlParams.kt
+++ b/data/src/main/java/org/tiqr/data/model/AuthenticationUrlParams.kt
@@ -1,0 +1,99 @@
+package org.tiqr.data.model
+
+import android.net.Uri
+import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
+import org.tiqr.data.BuildConfig
+import timber.log.Timber
+
+class AuthenticationUrlParams private constructor(
+    val username: String,
+    val protocolVersion: Int,
+    val sessionKey: String,
+    val challenge: String,
+    val serverIdentifier: String,
+    val returnUrl: String?
+) {
+    companion object {
+        /**
+         * Tries to parse the challenge authentication URL params from a given URL.
+         * If the parse could not complete because of missing information, null will be returned.
+         */
+        fun parseFromUrl(url: String): AuthenticationUrlParams? {
+            return if (url.startsWith("http")) {
+                // New format URL
+                parseNewFormatUrl(url)
+            } else if (url.startsWith(BuildConfig.TIQR_AUTH_SCHEME)) {
+                // Old format URL
+                parseOldFormatUrl(url)
+            } else {
+                Timber.i("Could not parse URL for authentication challenge, URL is: '$url'")
+                null
+            }
+        }
+
+        private fun parseOldFormatUrl(url: String): AuthenticationUrlParams? {
+            val httpUrl =
+                url.replaceFirst(BuildConfig.TIQR_AUTH_SCHEME, "http://").toHttpUrlOrNull()
+            if (httpUrl == null) {
+                Timber.w("Could not parse old format URL.")
+                return null
+            }
+            val username = httpUrl.username
+            val protocolVersion = httpUrl.pathSegments.getOrNull(3)?.toInt() ?: 0
+            val sessionKey = httpUrl.pathSegments[0]
+            val challenge = httpUrl.pathSegments[1]
+            val returnUrl = httpUrl.query?.toHttpUrlOrNull()?.toString()
+            val serverIdentifier = httpUrl.host
+            return AuthenticationUrlParams(
+                username = username,
+                protocolVersion = protocolVersion,
+                sessionKey = sessionKey,
+                challenge = challenge,
+                returnUrl = returnUrl,
+                serverIdentifier = serverIdentifier
+            )
+        }
+
+        private fun parseNewFormatUrl(url: String): AuthenticationUrlParams? {
+            val uri = try {
+                Uri.parse(url)
+            } catch (ex: Exception) {
+                Timber.w(ex, "Unable to parse URL: '$url'")
+                return null
+            }
+            if (BuildConfig.ENFORCE_CHALLENGE_HOST.isNotBlank()) {
+                val host = uri.host?.lowercase()
+                if (host == null ||
+                    (host != BuildConfig.ENFORCE_CHALLENGE_HOST && host.endsWith("." + BuildConfig.ENFORCE_CHALLENGE_HOST))
+                ) {
+                    Timber.w("Host was expected to be a subdomain of: ${BuildConfig.ENFORCE_CHALLENGE_HOST}, but it was actually: $host.");
+                    return null
+                }
+            }
+            val firstPathParam = uri.pathSegments.firstOrNull()
+            if (firstPathParam == null) {
+                Timber.w("Expected a path parameter, got nothing, this is not a valid challenge URL.")
+                return null
+            }
+            if (firstPathParam.lowercase() != BuildConfig.TIQR_AUTH_PATH_PARAM.lowercase()) {
+                Timber.w("Challenge URL not according to format. Expected path parameter: '${BuildConfig.TIQR_AUTH_PATH_PARAM}', got: '$firstPathParam'.")
+                return null
+            }
+            val username = uri.getQueryParameter("u") ?: return null
+            val protocolVersion = uri.getQueryParameter("v")?.toIntOrNull() ?: 0
+            val challenge = uri.getQueryParameter("c") ?: return null
+            val sessionKey = uri.getQueryParameter("s") ?: return null
+            val serverIdentifier = uri.getQueryParameter("i") ?: return null
+            val returnUrl: String? = null
+
+            return AuthenticationUrlParams(
+                username = username,
+                protocolVersion = protocolVersion,
+                sessionKey = sessionKey,
+                challenge = challenge,
+                returnUrl = returnUrl,
+                serverIdentifier = serverIdentifier
+            )
+        }
+    }
+}

--- a/data/src/main/java/org/tiqr/data/repository/base/ChallengeRepository.kt
+++ b/data/src/main/java/org/tiqr/data/repository/base/ChallengeRepository.kt
@@ -62,7 +62,7 @@ abstract class ChallengeRepository<T: Challenge> {
     /**
      * Contains a valid challenge?
      */
-    fun isValidChallenge(rawChallenge: String) = rawChallenge.startsWith(challengeScheme)
+    abstract fun isValidChallenge(rawChallenge: String): Boolean
 
     /**
      * Parse the raw challenge.

--- a/data/src/main/res/values-de/strings.xml
+++ b/data/src/main/res/values-de/strings.xml
@@ -16,7 +16,7 @@
     <string name="error_enroll_invalid_response">Ungültiges Registrierungsantwort. Bitte kontaktieren Sie den Webmaster.</string>
     <string name="error_enroll_invalid_response_code">Ungültiger Antwortcode (%s). Bitte kontaktieren Sie den Webmaster.</string>
     <string name="error_enroll_invalid_protocol">Ungültiges Antwortprotokoll (%s). Bitte kontaktieren Sie den Webmaster.</string>
-    <string name="error_enroll_duplicate_identity">Sie haben sich mit der Identität %1$s bereits beim Dienst %%2$s registriert.</string>
+    <string name="error_enroll_duplicate_identity">Sie haben sich mit der Identität %1$s bereits beim Dienst %2$s registriert.</string>
     <string name="error_enroll_saving_identity_provider">Identitätsprovider konnte nicht gespeichert werden. Bitte wenden Sie sich an den Support.</string>
     <string name="error_enroll_saving_identity">Identität konnte nicht gespeichert werden. Bitte wenden Sie sich an den Support.</string>
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -10,4 +10,7 @@ kotlin.incremental.usePreciseJavaTracking=true
 # SCHEME's
 schemeEnroll=tiqrenroll
 schemeAuth=tiqrauth
+enforceChallengeHost=tiqr.nl
+pathParamEnroll=tiqrenroll
+pathParamAuth=tiqrauth
 tokenExchangeEnabled=true


### PR DESCRIPTION
This adds support for doing enrolment & authentication from regular HTTPS URLs.
The old behavior is kept as well.
To support HTTPS URLs, you need to specify the following Gradle properties:
```
pathParamEnroll=tiqrenroll
pathParamAuth=tiqrauth
enforceChallengeHost=tiqr.nl
```
The `enforceChallengeHost` parameter is optional, but recommended, if you do support the new URL format.
