### PR TITLE
TIQR-308: Fix issues with migration, better logging

### DIFF
--- a/core/src/main/java/org/tiqr/core/util/databinding/BindingAdapters.kt
+++ b/core/src/main/java/org/tiqr/core/util/databinding/BindingAdapters.kt
@@ -177,6 +177,10 @@ fun RecyclerView.header(@LayoutRes view: Int) {
  */
 @BindingAdapter(value = ["loadImage"])
 fun ImageView.loadImage(url: String?) {
+    if (url.isNullOrEmpty()) {
+        setImageDrawable(null)
+        return
+    }
     load(url) {
         crossfade(true)
         listener(onError = { _, e -> Timber.e(e, "Error loading image from $url") })

--- a/data/schemas/org.tiqr.data.database.TiqrDatabase/9.json
+++ b/data/schemas/org.tiqr.data.database.TiqrDatabase/9.json
@@ -2,7 +2,7 @@
   "formatVersion": 1,
   "database": {
     "version": 9,
-    "identityHash": "91c9ba0b406e6f00ad2d01d03fb3a7e8",
+    "identityHash": "ae5babc07e1529d14e9f0a1a03bc931f",
     "entities": [
       {
         "tableName": "identity",
@@ -162,11 +162,11 @@
         "indices": [
           {
             "name": "index_identityprovider_identifier",
-            "unique": true,
+            "unique": false,
             "columnNames": [
               "identifier"
             ],
-            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_identityprovider_identifier` ON `${TABLE_NAME}` (`identifier`)"
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_identityprovider_identifier` ON `${TABLE_NAME}` (`identifier`)"
           }
         ],
         "foreignKeys": []
@@ -175,7 +175,7 @@
     "views": [],
     "setupQueries": [
       "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
-      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '91c9ba0b406e6f00ad2d01d03fb3a7e8')"
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'ae5babc07e1529d14e9f0a1a03bc931f')"
     ]
   }
 }

--- a/data/src/main/java/org/tiqr/data/database/TiqrDatabase.kt
+++ b/data/src/main/java/org/tiqr/data/database/TiqrDatabase.kt
@@ -33,7 +33,6 @@ import androidx.room.Database
 import androidx.room.RoomDatabase
 import androidx.room.migration.Migration
 import androidx.sqlite.db.SupportSQLiteDatabase
-import androidx.sqlite.db.transaction
 import org.tiqr.data.model.Identity
 import org.tiqr.data.model.IdentityProvider
 import timber.log.Timber
@@ -48,7 +47,7 @@ abstract class TiqrDatabase : RoomDatabase() {
                 Timber.d("Migrating database from version $startVersion to version $endVersion.")
                 Timber.d("Adds 2 columns.")
 
-                database.transaction {
+                database.run {
                     execSQL("ALTER TABLE identity ADD COLUMN showFingerPrintUpgrade INTEGER NOT NULL DEFAULT 1;")
                     execSQL("ALTER TABLE identity ADD COLUMN useFingerPrint INTEGER NOT NULL DEFAULT 0;")
                 }
@@ -60,7 +59,7 @@ abstract class TiqrDatabase : RoomDatabase() {
                 Timber.d("Migrating database from version $startVersion to version $endVersion.")
                 Timber.d("Changes LOGO from BLOB to TEXT.")
 
-                database.transaction {
+                database.run {
                     execSQL("CREATE TABLE new_identityprovider (_id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, displayName TEXT NOT NULL, identifier TEXT NOT NULL, authenticationUrl TEXT NOT NULL, ocraSuite TEXT NOT NULL, infoUrl TEXT, logo TEXT);")
                     execSQL("INSERT INTO new_identityprovider (_id, displayName, identifier, authenticationUrl, ocraSuite, infoUrl) SELECT _id, displayName, identifier, authenticationUrl, ocraSuite, infoUrl FROM identityprovider;")
                     execSQL("DROP TABLE identityprovider;")
@@ -71,12 +70,12 @@ abstract class TiqrDatabase : RoomDatabase() {
 
         // From version 8 onwards Room is being used
 
-        val FROM_7_TO_8: Migration = object : Migration(7,8) {
+        val FROM_7_TO_8: Migration = object : Migration(7, 8) {
             override fun migrate(database: SupportSQLiteDatabase) {
                 Timber.d("Migrating database from version $startVersion to version $endVersion.")
                 Timber.d("Adds FK's and indexes.")
 
-                database.transaction {
+                database.run {
                     execSQL("CREATE TABLE new_identity (_id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, displayName TEXT NOT NULL, identifier TEXT NOT NULL, identityProvider INTEGER NOT NULL, blocked INTEGER NOT NULL DEFAULT 0, sortIndex INTEGER NOT NULL, showFingerPrintUpgrade INTEGER NOT NULL DEFAULT 1, useFingerPrint INTEGER NOT NULL DEFAULT 0, FOREIGN KEY(identityProvider) REFERENCES identityprovider(_id) ON UPDATE NO ACTION ON DELETE CASCADE);")
                     execSQL("INSERT INTO new_identity (_id, displayName, identifier, identityProvider, blocked, sortIndex, showFingerPrintUpgrade, useFingerPrint) SELECT _id, displayName, identifier, identityProvider, blocked, sortIndex, showFingerPrintUpgrade, useFingerPrint FROM identity;")
                     execSQL("DROP TABLE identity;")
@@ -94,12 +93,12 @@ abstract class TiqrDatabase : RoomDatabase() {
             }
         }
 
-        val FROM_8_TO_9: Migration = object : Migration(8,9) {
+        val FROM_8_TO_9: Migration = object : Migration(8, 9) {
             override fun migrate(database: SupportSQLiteDatabase) {
                 Timber.d("Migrating database from version $startVersion to version $endVersion.")
                 Timber.d("Renames fingerprint to biometric. Renames indexes.")
 
-                database.transaction {
+                database.run {
                     execSQL("CREATE TABLE new_identity (_id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, displayName TEXT NOT NULL, identifier TEXT NOT NULL, identityProvider INTEGER NOT NULL, blocked INTEGER NOT NULL DEFAULT 0, sortIndex INTEGER NOT NULL, biometricInUse INTEGER NOT NULL DEFAULT 0, biometricOfferUpgrade INTEGER NOT NULL DEFAULT 1, FOREIGN KEY(identityProvider) REFERENCES identityprovider(_id) ON UPDATE NO ACTION ON DELETE RESTRICT)")
                     execSQL("INSERT INTO new_identity (_id, displayName, identifier, identityProvider, blocked, sortIndex, biometricInUse, biometricOfferUpgrade) SELECT _id, displayName, identifier, identityProvider, blocked, sortIndex, useFingerPrint, showFingerPrintUpgrade FROM identity;")
                     execSQL("DROP TABLE identity;")
@@ -112,7 +111,7 @@ abstract class TiqrDatabase : RoomDatabase() {
                     execSQL("INSERT INTO new_identityprovider (_id, displayName, identifier, authenticationUrl, ocraSuite, infoUrl, logo) SELECT _id, displayName, identifier, authenticationUrl, ocraSuite, infoUrl, logo FROM identityprovider;")
                     execSQL("DROP TABLE identityprovider;")
                     execSQL("ALTER TABLE new_identityprovider RENAME TO identityprovider;")
-                    execSQL("CREATE UNIQUE INDEX index_identityprovider_identifier ON identityprovider(identifier);")
+                    execSQL("CREATE INDEX index_identityprovider_identifier ON identityprovider(identifier);")
                 }
             }
         }

--- a/data/src/main/java/org/tiqr/data/model/IdentityProvider.kt
+++ b/data/src/main/java/org/tiqr/data/model/IdentityProvider.kt
@@ -41,7 +41,7 @@ import kotlinx.parcelize.Parcelize
  */
 @Entity(tableName = "identityprovider",
         indices = [
-                Index(value = ["identifier"], name = "index_identityprovider_identifier", unique = true)
+                Index(value = ["identifier"], name = "index_identityprovider_identifier", unique = false)
         ]
 )
 @Parcelize

--- a/data/src/main/java/org/tiqr/data/service/SecretService.kt
+++ b/data/src/main/java/org/tiqr/data/service/SecretService.kt
@@ -140,7 +140,7 @@ class SecretService(context: Context, preferenceService: PreferenceService) {
                     }
                 } catch (e: IOException) {
                     try {
-                        Timber.e(e, "Loading keystore failed, retrying with fallback")
+                        Timber.w(e, "Loading keystore failed, retrying with fallback")
                         context.openFileInput(KEYSTORE_FILENAME).use {
                             keyStore.load(it, encryption.deviceKey().encoded.toCharArrayCompat(CompatType.Fallback))
                             migrateKeystore = true

--- a/data/src/main/java/org/tiqr/data/viewmodel/StartViewModel.kt
+++ b/data/src/main/java/org/tiqr/data/viewmodel/StartViewModel.kt
@@ -37,6 +37,7 @@ import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.*
 import org.tiqr.data.R
 import org.tiqr.data.service.DatabaseService
+import timber.log.Timber
 import javax.inject.Inject
 
 /**
@@ -46,11 +47,17 @@ import javax.inject.Inject
 class StartViewModel @Inject constructor(db: DatabaseService) : ViewModel() {
     private val _identityCount: Flow<Int> = db.identityCount()
             .onStart { emit(value = 0) }
-            .catch { emit(value = 0) }
+            .catch { ex ->
+                Timber.w(ex, "Unable to determine identity count!")
+                emit(value = 0)
+            }
 
     private val _allIdentitiesBlocked: Flow<Boolean> = db.allIdentitiesBlocked()
             .onStart { emit(value = false) }
-            .catch { emit(value = false) }
+            .catch { ex ->
+                Timber.w(ex, "Unable to fetch all identities!")
+                emit(value = false)
+            }
 
     /**
      * Current number of identities.


### PR DESCRIPTION
### Pull Request Checklist
- [x] I have added proper commit messages
- [ ] I have updated tests and documentation - no, but I created a ticket to create migration tests (TIQR-309)
- [x] I ran the tests
- [x] I provided the ticket number as PR title
- [x] I have assigned the required reviewers

### Short Description of Change

Fixed two wrong assumptions in the migrations and added more logging.

### Motivation and Context

Peter has reported that the identities disappear after he added a few. He suspected it was because some of the identities don't have a logo.

### Testing Steps

Enroll with 2 identities at the same identity provider in the old app (3.1.0), then update to the latest version of the code

### Additional Information

I have tested a lot of cases, and the conclusion is that it has nothing to do with the logo itself (although there indeed is an error in the logcat about the logo not being shown). 

This actually happens when there are 2 identities from the same identity provider.

In this case, the migration script is being ran three times, that I could see from the logs.

It turns out that in the new version of the app, the database schema marked the property `identityprovider.identifier` as a unique key, but incorrectly. I removed the unique modifier, and also added a more logging on different places, so that we can catch these earlier, because this error was not visible in logcat.

After this fix, the app was still behaving incorrectly, the migrations were being ran endlessly after each other, repeating over and over. The cause turned out to be that we started a database transaction within the migration, but that's not how it should be done. After removing the transaction, the migration worked correctly.

Also, I added a small check that the app should not try to load an image if its URL is null or empty, so that we don't see error logs from the image loader if there's no logo URL defined.