### PR TITLE
TIQR-309: Tests for room migration

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -78,6 +78,11 @@ android {
         dataBinding = true
     }
 
+    sourceSets {
+        // Adds exported schema location as test app assets.
+        getByName("androidTest").assets.srcDir("$rootDir/data/schemas")
+    }
+
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_11
         targetCompatibility = JavaVersion.VERSION_11
@@ -98,6 +103,7 @@ android {
     lint {
         abortOnError = false
     }
+    namespace = "org.tiqr.sample"
 }
 
 dependencies {

--- a/app/src/androidTest/java/org/tiqr/data/database/DatabaseQueries.kt
+++ b/app/src/androidTest/java/org/tiqr/data/database/DatabaseQueries.kt
@@ -1,0 +1,34 @@
+package org.tiqr.data.database
+
+object DatabaseQueries {
+    const val V8_FIRST_PROVIDER =
+        """INSERT INTO identityprovider(_id,displayName,identifier,authenticationUrl,ocraSuite,infoUrl,logo)
+VALUES (0, "provider 0","v8 provider identifier", "url","ocra","infoUrl", "logoimage");"""
+    const val V8_SECOND_PROVIDER =
+        """INSERT INTO identityprovider(_id,displayName,identifier,authenticationUrl,ocraSuite,infoUrl,logo)
+VALUES (1, "provider 1","v8 provider identifier", "url","ocra","infoUrl", "logoimage");"""
+
+    const val V8_IDENTITY1_ON_FIRST_PROVIDER =
+        """INSERT INTO identity(displayName,identifier,identityprovider,blocked,sortIndex,showFingerPrintUpgrade,useFingerPrint)
+VALUES("v8 first identity from provider 0", "v8 identity identifier",0,0,1,1,0);"""
+
+    const val V8_IDENTITY2_ON_FIRST_PROVIDER =
+        """INSERT INTO identity(displayName,identifier,identityprovider,blocked,sortIndex,showFingerPrintUpgrade,useFingerPrint)
+VALUES ("v8 second identity from provider 0", "v8 identity identifier",0,0,1,1,0);"""
+
+    const val V8_IDENTITY1_ON_SECOND_PROVIDER =
+        """INSERT INTO identity(displayName,identifier,identityprovider,blocked,sortIndex,showFingerPrintUpgrade,useFingerPrint)
+VALUES ("v8 first identity from provider 1", "v8 identity identifier",1,0,1,1,0);"""
+
+    const val V8_IDENTITY2_ON_SECOND_PROVIDER =
+        """INSERT INTO identity(displayName,identifier,identityprovider,blocked,sortIndex,showFingerPrintUpgrade,useFingerPrint)
+VALUES("v8 second identity from provider 1", "v8 identity identifier",1,0,1,1,0);"""
+
+    const val V9_FIRST_PROVIDER = V8_FIRST_PROVIDER
+    const val V9_IDENTITY1_ON_FIRST_PROVIDER =
+        """INSERT INTO identity(displayName,identifier,identityprovider,blocked,sortIndex,biometricInUse,biometricOfferUpgrade)
+VALUES("v9 first identity from provider 0", "v9 identity identifier",0,0,1,1,0);"""
+    const val V9_IDENTITY2_ON_FIRST_PROVIDER =
+        """INSERT INTO identity(displayName,identifier,identityprovider,blocked,sortIndex,biometricInUse,biometricOfferUpgrade)
+VALUES("v9 first identity from provider 0", "v9 identity identifier",0,0,1,1,0);"""
+}

--- a/app/src/androidTest/java/org/tiqr/data/database/DatabaseQueries.kt
+++ b/app/src/androidTest/java/org/tiqr/data/database/DatabaseQueries.kt
@@ -3,10 +3,10 @@ package org.tiqr.data.database
 object DatabaseQueries {
     const val V8_FIRST_PROVIDER =
         """INSERT INTO identityprovider(_id,displayName,identifier,authenticationUrl,ocraSuite,infoUrl,logo)
-VALUES (0, "provider 0","v8 provider identifier", "url","ocra","infoUrl", "logoimage");"""
+VALUES (0, "provider 0","same identifier", "url","ocra","infoUrl", "logoimage");"""
     const val V8_SECOND_PROVIDER =
         """INSERT INTO identityprovider(_id,displayName,identifier,authenticationUrl,ocraSuite,infoUrl,logo)
-VALUES (1, "provider 1","v8 provider identifier", "url","ocra","infoUrl", "logoimage");"""
+VALUES (1, "provider 1","same identifier", "url","ocra","infoUrl", "logoimage");"""
 
     const val V8_IDENTITY1_ON_FIRST_PROVIDER =
         """INSERT INTO identity(displayName,identifier,identityprovider,blocked,sortIndex,showFingerPrintUpgrade,useFingerPrint)
@@ -24,11 +24,10 @@ VALUES ("v8 first identity from provider 1", "v8 identity identifier",1,0,1,1,0)
         """INSERT INTO identity(displayName,identifier,identityprovider,blocked,sortIndex,showFingerPrintUpgrade,useFingerPrint)
 VALUES("v8 second identity from provider 1", "v8 identity identifier",1,0,1,1,0);"""
 
-    const val V9_FIRST_PROVIDER = V8_FIRST_PROVIDER
-    const val V9_IDENTITY1_ON_FIRST_PROVIDER =
-        """INSERT INTO identity(displayName,identifier,identityprovider,blocked,sortIndex,biometricInUse,biometricOfferUpgrade)
-VALUES("v9 first identity from provider 0", "v9 identity identifier",0,0,1,1,0);"""
-    const val V9_IDENTITY2_ON_FIRST_PROVIDER =
-        """INSERT INTO identity(displayName,identifier,identityprovider,blocked,sortIndex,biometricInUse,biometricOfferUpgrade)
-VALUES("v9 first identity from provider 0", "v9 identity identifier",0,0,1,1,0);"""
+    const val V9_FIRST_PROVIDER =
+        """INSERT INTO identityprovider(_id,displayName,identifier,authenticationUrl,ocraSuite,infoUrl,logo)
+VALUES (0, "provider","same identifier", "url","ocra","infoUrl", "logoimage");"""
+    const val V9_SECOND_PROVIDER =
+        """INSERT INTO identityprovider(_id,displayName,identifier,authenticationUrl,ocraSuite,infoUrl,logo)
+VALUES (1, "provider","same identifier", "url","ocra","infoUrl", "logoimage");"""
 }

--- a/app/src/androidTest/java/org/tiqr/data/database/TiqrDatabaseTest.kt
+++ b/app/src/androidTest/java/org/tiqr/data/database/TiqrDatabaseTest.kt
@@ -1,0 +1,114 @@
+package org.tiqr.data.database
+
+import android.database.sqlite.SQLiteConstraintException
+import androidx.room.testing.MigrationTestHelper
+import androidx.sqlite.db.framework.FrameworkSQLiteOpenHelperFactory
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import okhttp3.internal.closeQuietly
+import org.junit.Assert.*
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.tiqr.data.database.DatabaseQueries.V8_FIRST_PROVIDER
+import org.tiqr.data.database.DatabaseQueries.V8_IDENTITY1_ON_FIRST_PROVIDER
+import org.tiqr.data.database.DatabaseQueries.V8_IDENTITY1_ON_SECOND_PROVIDER
+import org.tiqr.data.database.DatabaseQueries.V8_IDENTITY2_ON_FIRST_PROVIDER
+import org.tiqr.data.database.DatabaseQueries.V8_IDENTITY2_ON_SECOND_PROVIDER
+import org.tiqr.data.database.DatabaseQueries.V8_SECOND_PROVIDER
+import org.tiqr.data.database.DatabaseQueries.V9_FIRST_PROVIDER
+import org.tiqr.data.database.DatabaseQueries.V9_IDENTITY1_ON_FIRST_PROVIDER
+import org.tiqr.data.database.DatabaseQueries.V9_IDENTITY2_ON_FIRST_PROVIDER
+import org.tiqr.data.database.TiqrDatabase.Companion.FROM_8_TO_10
+import org.tiqr.data.database.TiqrDatabase.Companion.FROM_8_TO_9
+import timber.log.Timber
+
+@RunWith(AndroidJUnit4::class)
+class TiqrDatabaseMigrationTest {
+    private val TEST_DB = "migration-test"
+
+    @get:Rule
+    val helper: MigrationTestHelper = MigrationTestHelper(
+        /* instrumentation = */ InstrumentationRegistry.getInstrumentation(),
+        /* assetsFolder = */ TiqrDatabase::class.java.canonicalName,
+        /* openFactory = */ FrameworkSQLiteOpenHelperFactory()
+    )
+
+    @Test
+    fun givenV8ThenMigrateV9ThenIntegrityOk() {
+        createV8WithData()
+
+        try {
+            helper.runMigrationsAndValidate(TEST_DB, 9, true, FROM_8_TO_9)
+        } catch (e: SQLiteConstraintException) {
+            Timber.i("Expected 8 to 9 migration failure")
+        }
+        helper.createDatabase(TEST_DB, 9).apply {
+            assertEquals(
+                /* message = */ "DB integrity compromised after 8 to 9 migration",
+                /* expected = */ true,
+                /* actual = */ isDatabaseIntegrityOk
+            )
+            assertEquals(
+                /* message = */ "Migration incremented the version",
+                /* expected = */ 9,
+                /* actual = */ version
+            )
+            this.version
+            close()
+        }
+    }
+
+    @Test
+    fun givenV9UniqueIndexThenFailSameProviderIdentities() {
+        helper.createDatabase(TEST_DB, 9).apply {
+            try {
+                execSQL(V9_FIRST_PROVIDER)
+                execSQL(V9_IDENTITY1_ON_FIRST_PROVIDER)
+                execSQL(V9_IDENTITY2_ON_FIRST_PROVIDER)
+            } catch (e: SQLiteConstraintException) {
+                Timber.e(e, "Failed to insert data into v9")
+            }
+            val cursor = query("SELECT * FROM identity WHERE identityprovider=0")
+            assertEquals(
+                /* message = */ "Not able to add multiple identities for the same provider",
+                /* expected = */ 1,
+                /* actual = */ cursor.count
+            )
+            cursor.closeQuietly()
+            close()
+        }
+    }
+
+    @Test
+    fun givenV8WhenMigrateV10ThenNoDataLoss() {
+        createV8WithData()
+
+        try {
+            val db = helper.runMigrationsAndValidate(TEST_DB, 10, true, FROM_8_TO_10)
+            val cursor = db.query("SELECT * FROM identity WHERE identityprovider=0")
+            assertEquals(
+                /* message = */ "After 8 to 10 migration there is no data loss",
+                /* expected = */ 2,
+                /* actual = */ cursor.count
+            )
+            cursor.closeQuietly()
+            db.close()
+        } catch (e: SQLiteConstraintException) {
+            Timber.e(e, "Failed migration from 9 to 10")
+        }
+    }
+
+    private fun createV8WithData() {
+        helper.createDatabase(TEST_DB, 8).apply {
+            execSQL(V8_FIRST_PROVIDER)
+            execSQL(V8_SECOND_PROVIDER)
+            execSQL(V8_IDENTITY1_ON_FIRST_PROVIDER)
+            execSQL(V8_IDENTITY2_ON_FIRST_PROVIDER)
+            execSQL(V8_IDENTITY1_ON_SECOND_PROVIDER)
+            execSQL(V8_IDENTITY2_ON_SECOND_PROVIDER)
+            close()
+        }
+    }
+}
+

--- a/app/src/androidTest/java/org/tiqr/data/database/TiqrDatabaseTest.kt
+++ b/app/src/androidTest/java/org/tiqr/data/database/TiqrDatabaseTest.kt
@@ -30,7 +30,7 @@ class TiqrDatabaseMigrationTest {
     @get:Rule
     val helper: MigrationTestHelper = MigrationTestHelper(
         /* instrumentation = */ InstrumentationRegistry.getInstrumentation(),
-        /* assetsFolder = */ TiqrDatabase::class.java.canonicalName,
+        /* assetsFolder = */ "schemas/${TiqrDatabase::class.java.canonicalName}",
         /* openFactory = */ FrameworkSQLiteOpenHelperFactory()
     )
 

--- a/app/src/androidTest/java/org/tiqr/data/database/TiqrDatabaseTest.kt
+++ b/app/src/androidTest/java/org/tiqr/data/database/TiqrDatabaseTest.kt
@@ -58,7 +58,7 @@ class TiqrDatabaseMigrationTest {
 
     @Test
     fun givenV9UniqueIndexThenFailSameProviderIdentitifier() {
-        helper.createDatabase("fail_insert", 9).apply {
+        helper.createDatabase(TEST_DB, 9).apply {
             try {
                 execSQL(V9_FIRST_PROVIDER)
                 execSQL(V9_SECOND_PROVIDER)

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,8 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
-    tools:ignore="UnusedAttribute"
-    package="org.tiqr.sample">
+    tools:ignore="UnusedAttribute">
 
     <uses-permission android:name="android.permission.USE_BIOMETRIC" />
     <!-- Permissions for QR code scanning -->

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -53,6 +53,7 @@ android {
             jvmTarget = JavaVersion.VERSION_11.toString()
         }
     }
+    namespace = "org.tiqr.core"
 }
 
 fun loadCustomProperties(file: File): java.util.Properties {

--- a/core/src/main/AndroidManifest.xml
+++ b/core/src/main/AndroidManifest.xml
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="org.tiqr.core">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
 </manifest>

--- a/data/build.gradle.kts
+++ b/data/build.gradle.kts
@@ -1,4 +1,4 @@
-import java.util.Properties
+import java.util.*
 
 plugins {
     id("com.android.library")
@@ -34,6 +34,11 @@ android {
         consumerProguardFiles("consumer-rules.pro")
     }
 
+    sourceSets {
+        // Adds exported schema location as test app assets.
+        getByName("androidTest").assets.srcDir("$projectDir/schemas")
+    }
+
     buildTypes {
         getByName("release") {
             isMinifyEnabled = true
@@ -56,7 +61,7 @@ android {
             }
 
             arguments {
-                arg("room.schemaLocation", "$projectDir/schemas".toString())
+                arg("room.schemaLocation", "$projectDir/schemas")
                 arg("room.incremental", "true")
             }
         }
@@ -101,6 +106,7 @@ android {
         api(libs.timber)
 
         testImplementation(libs.junit)
+        testImplementation("androidx.room:room-testing:2.4.3")
         androidTestImplementation(libs.androidx.testing.junit)
         androidTestImplementation(libs.androidx.testing.epsresso)
         androidTestImplementation(libs.kotlinx.coroutines.test)

--- a/data/build.gradle.kts
+++ b/data/build.gradle.kts
@@ -34,11 +34,6 @@ android {
         consumerProguardFiles("consumer-rules.pro")
     }
 
-    sourceSets {
-        // Adds exported schema location as test app assets.
-        getByName("androidTest").assets.srcDir("$projectDir/schemas")
-    }
-
     buildTypes {
         getByName("release") {
             isMinifyEnabled = true
@@ -76,6 +71,8 @@ android {
         }
     }
 
+    namespace = "org.tiqr.data"
+
     dependencies {
         implementation(libs.kotlin.stdlib)
         implementation(libs.kotlinx.coroutines.core)
@@ -106,7 +103,7 @@ android {
         api(libs.timber)
 
         testImplementation(libs.junit)
-        testImplementation("androidx.room:room-testing:2.4.3")
+        testImplementation(libs.androidx.room.testing)
         androidTestImplementation(libs.androidx.testing.junit)
         androidTestImplementation(libs.androidx.testing.epsresso)
         androidTestImplementation(libs.kotlinx.coroutines.test)

--- a/data/schemas/org.tiqr.data.database.TiqrDatabase/10.json
+++ b/data/schemas/org.tiqr.data.database.TiqrDatabase/10.json
@@ -1,7 +1,7 @@
 {
   "formatVersion": 1,
   "database": {
-    "version": 9,
+    "version": 10,
     "identityHash": "91c9ba0b406e6f00ad2d01d03fb3a7e8",
     "entities": [
       {
@@ -61,10 +61,10 @@
           }
         ],
         "primaryKey": {
-          "autoGenerate": true,
           "columnNames": [
             "_id"
-          ]
+          ],
+          "autoGenerate": true
         },
         "indices": [
           {
@@ -73,7 +73,6 @@
             "columnNames": [
               "_id"
             ],
-            "orders": [],
             "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_identity_id` ON `${TABLE_NAME}` (`_id`)"
           },
           {
@@ -82,7 +81,6 @@
             "columnNames": [
               "identifier"
             ],
-            "orders": [],
             "createSql": "CREATE INDEX IF NOT EXISTS `index_identity_identifier` ON `${TABLE_NAME}` (`identifier`)"
           },
           {
@@ -91,7 +89,6 @@
             "columnNames": [
               "identityProvider"
             ],
-            "orders": [],
             "createSql": "CREATE INDEX IF NOT EXISTS `index_identity_identityProvider` ON `${TABLE_NAME}` (`identityProvider`)"
           }
         ],
@@ -157,20 +154,19 @@
           }
         ],
         "primaryKey": {
-          "autoGenerate": true,
           "columnNames": [
             "_id"
-          ]
+          ],
+          "autoGenerate": true
         },
         "indices": [
           {
             "name": "index_identityprovider_identifier",
-            "unique": true,
+            "unique": false,
             "columnNames": [
               "identifier"
             ],
-            "orders": [],
-            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_identityprovider_identifier` ON `${TABLE_NAME}` (`identifier`)"
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_identityprovider_identifier` ON `${TABLE_NAME}` (`identifier`)"
           }
         ],
         "foreignKeys": []

--- a/data/src/main/AndroidManifest.xml
+++ b/data/src/main/AndroidManifest.xml
@@ -1,5 +1,4 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="org.tiqr.data" >
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <uses-permission android:name="android.permission.INTERNET" />
 </manifest>

--- a/data/src/main/java/org/tiqr/data/database/Migrations.kt
+++ b/data/src/main/java/org/tiqr/data/database/Migrations.kt
@@ -1,0 +1,123 @@
+package org.tiqr.data.database
+
+import androidx.room.migration.Migration
+import androidx.sqlite.db.SupportSQLiteDatabase
+import timber.log.Timber
+
+val FROM_4_TO_5: Migration = object : Migration(4, 5) {
+    override fun migrate(database: SupportSQLiteDatabase) {
+        Timber.d("Migrating database from version $startVersion to version $endVersion.")
+        Timber.d("Adds 2 columns.")
+
+        database.run {
+            execSQL("ALTER TABLE identity ADD COLUMN showFingerPrintUpgrade INTEGER NOT NULL DEFAULT 1;")
+            execSQL("ALTER TABLE identity ADD COLUMN useFingerPrint INTEGER NOT NULL DEFAULT 0;")
+        }
+    }
+}
+
+val FROM_5_TO_7: Migration = object : Migration(5, 7) {
+    override fun migrate(database: SupportSQLiteDatabase) {
+        Timber.d("Migrating database from version $startVersion to version $endVersion.")
+        Timber.d("Changes LOGO from BLOB to TEXT.")
+
+        database.run {
+            execSQL("CREATE TABLE new_identityprovider (_id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, displayName TEXT NOT NULL, identifier TEXT NOT NULL, authenticationUrl TEXT NOT NULL, ocraSuite TEXT NOT NULL, infoUrl TEXT, logo TEXT);")
+            execSQL("INSERT INTO new_identityprovider (_id, displayName, identifier, authenticationUrl, ocraSuite, infoUrl) SELECT _id, displayName, identifier, authenticationUrl, ocraSuite, infoUrl FROM identityprovider;")
+            execSQL("DROP TABLE identityprovider;")
+            execSQL("ALTER TABLE new_identityprovider RENAME TO identityprovider;")
+        }
+    }
+}
+
+// From version 8 onwards Room is being used
+val FROM_7_TO_8: Migration = object : Migration(7, 8) {
+    override fun migrate(database: SupportSQLiteDatabase) {
+        Timber.d("Migrating database from version $startVersion to version $endVersion.")
+        Timber.d("Adds FK's and indexes.")
+
+        database.run {
+            execSQL("CREATE TABLE new_identity (_id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, displayName TEXT NOT NULL, identifier TEXT NOT NULL, identityProvider INTEGER NOT NULL, blocked INTEGER NOT NULL DEFAULT 0, sortIndex INTEGER NOT NULL, showFingerPrintUpgrade INTEGER NOT NULL DEFAULT 1, useFingerPrint INTEGER NOT NULL DEFAULT 0, FOREIGN KEY(identityProvider) REFERENCES identityprovider(_id) ON UPDATE NO ACTION ON DELETE CASCADE);")
+            execSQL("INSERT INTO new_identity (_id, displayName, identifier, identityProvider, blocked, sortIndex, showFingerPrintUpgrade, useFingerPrint) SELECT _id, displayName, identifier, identityProvider, blocked, sortIndex, showFingerPrintUpgrade, useFingerPrint FROM identity;")
+            execSQL("DROP TABLE identity;")
+            execSQL("ALTER TABLE new_identity RENAME TO identity;")
+            execSQL("CREATE UNIQUE INDEX id_idx ON identity(_id);")
+            execSQL("CREATE INDEX identifier_idx ON identity(identifier);")
+            execSQL("CREATE INDEX identity_provider_idx ON identity(identityProvider);")
+
+            execSQL("CREATE TABLE new_identityprovider (_id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, displayName TEXT NOT NULL, identifier TEXT NOT NULL, authenticationUrl TEXT NOT NULL, ocraSuite TEXT NOT NULL, infoUrl TEXT, logo TEXT);")
+            execSQL("INSERT INTO new_identityprovider (_id, displayName, identifier, authenticationUrl, ocraSuite, infoUrl, logo) SELECT _id, displayName, identifier, authenticationUrl, ocraSuite, infoUrl, logo FROM identityprovider;")
+            execSQL("DROP TABLE identityprovider;")
+            execSQL("ALTER TABLE new_identityprovider RENAME TO identityprovider;")
+            execSQL("CREATE INDEX ip_identifier_idx ON identityprovider(identifier)")
+        }
+    }
+}
+
+@Deprecated("The migration from 8 to 9 is using a unique index on the identityprovider table which is wrong. Migrating to this version 9 can lead to data loss for users.")
+val FROM_8_TO_9: Migration = object : Migration(8, 9) {
+    override fun migrate(database: SupportSQLiteDatabase) {
+        Timber.d("Migrating database from version $startVersion to version $endVersion.")
+        Timber.d("Renames fingerprint to biometric. Renames indexes.")
+
+        database.run {
+            execSQL("CREATE TABLE new_identity (_id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, displayName TEXT NOT NULL, identifier TEXT NOT NULL, identityProvider INTEGER NOT NULL, blocked INTEGER NOT NULL DEFAULT 0, sortIndex INTEGER NOT NULL, biometricInUse INTEGER NOT NULL DEFAULT 0, biometricOfferUpgrade INTEGER NOT NULL DEFAULT 1, FOREIGN KEY(identityProvider) REFERENCES identityprovider(_id) ON UPDATE NO ACTION ON DELETE RESTRICT)")
+            execSQL("INSERT INTO new_identity (_id, displayName, identifier, identityProvider, blocked, sortIndex, biometricInUse, biometricOfferUpgrade) SELECT _id, displayName, identifier, identityProvider, blocked, sortIndex, useFingerPrint, showFingerPrintUpgrade FROM identity;")
+            execSQL("DROP TABLE identity;")
+            execSQL("ALTER TABLE new_identity RENAME TO identity;")
+            execSQL("CREATE UNIQUE INDEX index_identity_id ON identity(_id);")
+            execSQL("CREATE INDEX index_identity_identifier ON identity(identifier);")
+            execSQL("CREATE INDEX index_identity_identityProvider ON identity(identityProvider);")
+
+            execSQL("CREATE TABLE new_identityprovider (_id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, displayName TEXT NOT NULL, identifier TEXT NOT NULL, authenticationUrl TEXT NOT NULL, ocraSuite TEXT NOT NULL, infoUrl TEXT, logo TEXT);")
+            execSQL("INSERT INTO new_identityprovider (_id, displayName, identifier, authenticationUrl, ocraSuite, infoUrl, logo) SELECT _id, displayName, identifier, authenticationUrl, ocraSuite, infoUrl, logo FROM identityprovider;")
+            execSQL("DROP TABLE identityprovider;")
+            execSQL("ALTER TABLE new_identityprovider RENAME TO identityprovider;")
+            execSQL("CREATE UNIQUE INDEX index_identityprovider_identifier ON identityprovider(identifier);")
+        }
+    }
+}
+
+val FROM_8_TO_10: Migration = object : Migration(8, 10) {
+    override fun migrate(database: SupportSQLiteDatabase) {
+        Timber.d("Migrating database from version $startVersion to version $endVersion.")
+        Timber.d("Renames fingerprint to biometric. Recreates indexes for identity table and renames it for identityprovider (ip_identifier_idx->index_identityprovider_identifier)")
+
+        database.run {
+            execSQL("CREATE TABLE new_identity (_id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, displayName TEXT NOT NULL, identifier TEXT NOT NULL, identityProvider INTEGER NOT NULL, blocked INTEGER NOT NULL DEFAULT 0, sortIndex INTEGER NOT NULL, biometricInUse INTEGER NOT NULL DEFAULT 0, biometricOfferUpgrade INTEGER NOT NULL DEFAULT 1, FOREIGN KEY(identityProvider) REFERENCES identityprovider(_id) ON UPDATE NO ACTION ON DELETE RESTRICT)")
+            execSQL("INSERT INTO new_identity (_id, displayName, identifier, identityProvider, blocked, sortIndex, biometricInUse, biometricOfferUpgrade) SELECT _id, displayName, identifier, identityProvider, blocked, sortIndex, useFingerPrint, showFingerPrintUpgrade FROM identity;")
+            execSQL("DROP TABLE identity;")
+            execSQL("ALTER TABLE new_identity RENAME TO identity;")
+            execSQL("CREATE UNIQUE INDEX index_identity_id ON identity(_id)")
+            execSQL("CREATE INDEX index_identity_identifier ON identity(identifier)")
+            execSQL("CREATE INDEX index_identity_identityProvider ON identity(identityProvider)")
+
+            execSQL("DROP INDEX ip_identifier_idx;")
+            execSQL("CREATE INDEX index_identityprovider_identifier ON identityprovider(identifier);")
+        }
+    }
+}
+
+/**
+ * For the apps that have already migrated to version 9 and have already experienced data loss, we still have to drop the unique index
+ * and create it as not unique.
+ * */
+val FROM_9_TO_10: Migration = object : Migration(9, 10) {
+    override fun migrate(database: SupportSQLiteDatabase) {
+        Timber.d("Migrating database from version $startVersion to version $endVersion.")
+        Timber.d("Drops the unique index `index_identityprovider_identifier` and recreates it as not unique for table identityprovider.")
+
+        database.run {
+            execSQL("DROP INDEX index_identityprovider_identifier;")
+            execSQL("CREATE INDEX index_identityprovider_identifier ON identityprovider(identifier);")
+        }
+    }
+}
+
+val ALL_VALID_MIGRATIONS = arrayOf(
+    FROM_4_TO_5,
+    FROM_5_TO_7,
+    FROM_7_TO_8,
+    FROM_8_TO_10,
+    FROM_9_TO_10,
+)

--- a/data/src/main/java/org/tiqr/data/database/Migrations.kt
+++ b/data/src/main/java/org/tiqr/data/database/Migrations.kt
@@ -49,7 +49,7 @@ val FROM_7_TO_8: Migration = object : Migration(7, 8) {
             execSQL("INSERT INTO new_identityprovider (_id, displayName, identifier, authenticationUrl, ocraSuite, infoUrl, logo) SELECT _id, displayName, identifier, authenticationUrl, ocraSuite, infoUrl, logo FROM identityprovider;")
             execSQL("DROP TABLE identityprovider;")
             execSQL("ALTER TABLE new_identityprovider RENAME TO identityprovider;")
-            execSQL("CREATE INDEX ip_identifier_idx ON identityprovider(identifier)")
+            execSQL("CREATE INDEX ip_identifier_idx ON identityprovider(identifier);")
         }
     }
 }
@@ -61,7 +61,7 @@ val FROM_8_TO_9: Migration = object : Migration(8, 9) {
         Timber.d("Renames fingerprint to biometric. Renames indexes.")
 
         database.run {
-            execSQL("CREATE TABLE new_identity (_id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, displayName TEXT NOT NULL, identifier TEXT NOT NULL, identityProvider INTEGER NOT NULL, blocked INTEGER NOT NULL DEFAULT 0, sortIndex INTEGER NOT NULL, biometricInUse INTEGER NOT NULL DEFAULT 0, biometricOfferUpgrade INTEGER NOT NULL DEFAULT 1, FOREIGN KEY(identityProvider) REFERENCES identityprovider(_id) ON UPDATE NO ACTION ON DELETE RESTRICT)")
+            execSQL("CREATE TABLE new_identity (_id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, displayName TEXT NOT NULL, identifier TEXT NOT NULL, identityProvider INTEGER NOT NULL, blocked INTEGER NOT NULL DEFAULT 0, sortIndex INTEGER NOT NULL, biometricInUse INTEGER NOT NULL DEFAULT 0, biometricOfferUpgrade INTEGER NOT NULL DEFAULT 1, FOREIGN KEY(identityProvider) REFERENCES identityprovider(_id) ON UPDATE NO ACTION ON DELETE RESTRICT);")
             execSQL("INSERT INTO new_identity (_id, displayName, identifier, identityProvider, blocked, sortIndex, biometricInUse, biometricOfferUpgrade) SELECT _id, displayName, identifier, identityProvider, blocked, sortIndex, useFingerPrint, showFingerPrintUpgrade FROM identity;")
             execSQL("DROP TABLE identity;")
             execSQL("ALTER TABLE new_identity RENAME TO identity;")
@@ -84,13 +84,13 @@ val FROM_8_TO_10: Migration = object : Migration(8, 10) {
         Timber.d("Renames fingerprint to biometric. Recreates indexes for identity table and renames it for identityprovider (ip_identifier_idx->index_identityprovider_identifier)")
 
         database.run {
-            execSQL("CREATE TABLE new_identity (_id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, displayName TEXT NOT NULL, identifier TEXT NOT NULL, identityProvider INTEGER NOT NULL, blocked INTEGER NOT NULL DEFAULT 0, sortIndex INTEGER NOT NULL, biometricInUse INTEGER NOT NULL DEFAULT 0, biometricOfferUpgrade INTEGER NOT NULL DEFAULT 1, FOREIGN KEY(identityProvider) REFERENCES identityprovider(_id) ON UPDATE NO ACTION ON DELETE RESTRICT)")
+            execSQL("CREATE TABLE new_identity (_id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, displayName TEXT NOT NULL, identifier TEXT NOT NULL, identityProvider INTEGER NOT NULL, blocked INTEGER NOT NULL DEFAULT 0, sortIndex INTEGER NOT NULL, biometricInUse INTEGER NOT NULL DEFAULT 0, biometricOfferUpgrade INTEGER NOT NULL DEFAULT 1, FOREIGN KEY(identityProvider) REFERENCES identityprovider(_id) ON UPDATE NO ACTION ON DELETE RESTRICT);")
             execSQL("INSERT INTO new_identity (_id, displayName, identifier, identityProvider, blocked, sortIndex, biometricInUse, biometricOfferUpgrade) SELECT _id, displayName, identifier, identityProvider, blocked, sortIndex, useFingerPrint, showFingerPrintUpgrade FROM identity;")
             execSQL("DROP TABLE identity;")
             execSQL("ALTER TABLE new_identity RENAME TO identity;")
-            execSQL("CREATE UNIQUE INDEX index_identity_id ON identity(_id)")
-            execSQL("CREATE INDEX index_identity_identifier ON identity(identifier)")
-            execSQL("CREATE INDEX index_identity_identityProvider ON identity(identityProvider)")
+            execSQL("CREATE UNIQUE INDEX index_identity_id ON identity(_id);")
+            execSQL("CREATE INDEX index_identity_identifier ON identity(identifier);")
+            execSQL("CREATE INDEX index_identity_identityProvider ON identity(identityProvider);")
 
             execSQL("DROP INDEX ip_identifier_idx;")
             execSQL("CREATE INDEX index_identityprovider_identifier ON identityprovider(identifier);")

--- a/data/src/main/java/org/tiqr/data/database/TiqrDatabase.kt
+++ b/data/src/main/java/org/tiqr/data/database/TiqrDatabase.kt
@@ -69,7 +69,6 @@ abstract class TiqrDatabase : RoomDatabase() {
         }
 
         // From version 8 onwards Room is being used
-
         val FROM_7_TO_8: Migration = object : Migration(7, 8) {
             override fun migrate(database: SupportSQLiteDatabase) {
                 Timber.d("Migrating database from version $startVersion to version $endVersion.")
@@ -93,6 +92,7 @@ abstract class TiqrDatabase : RoomDatabase() {
             }
         }
 
+        @Deprecated("The migration from 8 to 9 is using a unique index on the identityprovider table which is wrong. Migrating to this version 9 can lead to data loss for users.")
         val FROM_8_TO_9: Migration = object : Migration(8, 9) {
             override fun migrate(database: SupportSQLiteDatabase) {
                 Timber.d("Migrating database from version $startVersion to version $endVersion.")
@@ -103,14 +103,46 @@ abstract class TiqrDatabase : RoomDatabase() {
                     execSQL("INSERT INTO new_identity (_id, displayName, identifier, identityProvider, blocked, sortIndex, biometricInUse, biometricOfferUpgrade) SELECT _id, displayName, identifier, identityProvider, blocked, sortIndex, useFingerPrint, showFingerPrintUpgrade FROM identity;")
                     execSQL("DROP TABLE identity;")
                     execSQL("ALTER TABLE new_identity RENAME TO identity;")
+                    execSQL("CREATE UNIQUE INDEX index_identity_id ON identity(_id);")
+                    execSQL("CREATE INDEX index_identity_identifier ON identity(identifier);")
+                    execSQL("CREATE INDEX index_identity_identityProvider ON identity(identityProvider);")
+
+                    execSQL("DROP INDEX ip_identifier_idx;")
+                    execSQL("CREATE UNIQUE INDEX index_identityprovider_identifier ON identityprovider(identifier);")
+                }
+            }
+        }
+
+        val FROM_8_TO_10: Migration = object : Migration(8, 10) {
+            override fun migrate(database: SupportSQLiteDatabase) {
+                Timber.d("Migrating database from version $startVersion to version $endVersion.")
+                Timber.d("Renames fingerprint to biometric. Renames indexes. Creates non-unique index on identityprovider(identifier)")
+
+                database.run {
+                    execSQL("CREATE TABLE new_identity (_id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, displayName TEXT NOT NULL, identifier TEXT NOT NULL, identityProvider INTEGER NOT NULL, blocked INTEGER NOT NULL DEFAULT 0, sortIndex INTEGER NOT NULL, biometricInUse INTEGER NOT NULL DEFAULT 0, biometricOfferUpgrade INTEGER NOT NULL DEFAULT 1, FOREIGN KEY(identityProvider) REFERENCES identityprovider(_id) ON UPDATE NO ACTION ON DELETE RESTRICT)")
+                    execSQL("INSERT INTO new_identity (_id, displayName, identifier, identityProvider, blocked, sortIndex, biometricInUse, biometricOfferUpgrade) SELECT _id, displayName, identifier, identityProvider, blocked, sortIndex, useFingerPrint, showFingerPrintUpgrade FROM identity;")
+                    execSQL("DROP TABLE identity;")
+                    execSQL("ALTER TABLE new_identity RENAME TO identity;")
                     execSQL("CREATE UNIQUE INDEX index_identity_id ON identity(_id)")
                     execSQL("CREATE INDEX index_identity_identifier ON identity(identifier)")
                     execSQL("CREATE INDEX index_identity_identityProvider ON identity(identityProvider)")
 
-                    execSQL("CREATE TABLE new_identityprovider (_id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, displayName TEXT NOT NULL, identifier TEXT NOT NULL, authenticationUrl TEXT NOT NULL, ocraSuite TEXT NOT NULL, infoUrl TEXT, logo TEXT);")
-                    execSQL("INSERT INTO new_identityprovider (_id, displayName, identifier, authenticationUrl, ocraSuite, infoUrl, logo) SELECT _id, displayName, identifier, authenticationUrl, ocraSuite, infoUrl, logo FROM identityprovider;")
-                    execSQL("DROP TABLE identityprovider;")
-                    execSQL("ALTER TABLE new_identityprovider RENAME TO identityprovider;")
+                    execSQL("CREATE INDEX index_identityprovider_identifier ON identityprovider(identifier);")
+                }
+            }
+        }
+
+        /**
+         * For the apps that have already migrated to version 9 and have already experienced data loss, we still have to drop the unique index
+         * and create it as not unique.
+         * */
+        val FROM_9_TO_10: Migration = object : Migration(9, 10) {
+            override fun migrate(database: SupportSQLiteDatabase) {
+                Timber.d("Migrating database from version $startVersion to version $endVersion.")
+                Timber.d("Drops the unique index `index_identityprovider_identifier` and recreates it as not unique.")
+
+                database.run {
+                    execSQL("DROP INDEX index_identityprovider_identifier;")
                     execSQL("CREATE INDEX index_identityprovider_identifier ON identityprovider(identifier);")
                 }
             }

--- a/data/src/main/java/org/tiqr/data/database/TiqrDatabase.kt
+++ b/data/src/main/java/org/tiqr/data/database/TiqrDatabase.kt
@@ -31,122 +31,13 @@ package org.tiqr.data.database
 
 import androidx.room.Database
 import androidx.room.RoomDatabase
-import androidx.room.migration.Migration
-import androidx.sqlite.db.SupportSQLiteDatabase
 import org.tiqr.data.model.Identity
 import org.tiqr.data.model.IdentityProvider
-import timber.log.Timber
 
-@Database(entities = [Identity::class, IdentityProvider::class], version = 9, exportSchema = true)
+@Database(entities = [Identity::class, IdentityProvider::class], version = 10, exportSchema = true)
 abstract class TiqrDatabase : RoomDatabase() {
     companion object {
         const val DB_NAME = "identities.db"
-
-        val FROM_4_TO_5: Migration = object : Migration(4, 5) {
-            override fun migrate(database: SupportSQLiteDatabase) {
-                Timber.d("Migrating database from version $startVersion to version $endVersion.")
-                Timber.d("Adds 2 columns.")
-
-                database.run {
-                    execSQL("ALTER TABLE identity ADD COLUMN showFingerPrintUpgrade INTEGER NOT NULL DEFAULT 1;")
-                    execSQL("ALTER TABLE identity ADD COLUMN useFingerPrint INTEGER NOT NULL DEFAULT 0;")
-                }
-            }
-        }
-
-        val FROM_5_TO_7: Migration = object : Migration(5, 7) {
-            override fun migrate(database: SupportSQLiteDatabase) {
-                Timber.d("Migrating database from version $startVersion to version $endVersion.")
-                Timber.d("Changes LOGO from BLOB to TEXT.")
-
-                database.run {
-                    execSQL("CREATE TABLE new_identityprovider (_id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, displayName TEXT NOT NULL, identifier TEXT NOT NULL, authenticationUrl TEXT NOT NULL, ocraSuite TEXT NOT NULL, infoUrl TEXT, logo TEXT);")
-                    execSQL("INSERT INTO new_identityprovider (_id, displayName, identifier, authenticationUrl, ocraSuite, infoUrl) SELECT _id, displayName, identifier, authenticationUrl, ocraSuite, infoUrl FROM identityprovider;")
-                    execSQL("DROP TABLE identityprovider;")
-                    execSQL("ALTER TABLE new_identityprovider RENAME TO identityprovider;")
-                }
-            }
-        }
-
-        // From version 8 onwards Room is being used
-        val FROM_7_TO_8: Migration = object : Migration(7, 8) {
-            override fun migrate(database: SupportSQLiteDatabase) {
-                Timber.d("Migrating database from version $startVersion to version $endVersion.")
-                Timber.d("Adds FK's and indexes.")
-
-                database.run {
-                    execSQL("CREATE TABLE new_identity (_id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, displayName TEXT NOT NULL, identifier TEXT NOT NULL, identityProvider INTEGER NOT NULL, blocked INTEGER NOT NULL DEFAULT 0, sortIndex INTEGER NOT NULL, showFingerPrintUpgrade INTEGER NOT NULL DEFAULT 1, useFingerPrint INTEGER NOT NULL DEFAULT 0, FOREIGN KEY(identityProvider) REFERENCES identityprovider(_id) ON UPDATE NO ACTION ON DELETE CASCADE);")
-                    execSQL("INSERT INTO new_identity (_id, displayName, identifier, identityProvider, blocked, sortIndex, showFingerPrintUpgrade, useFingerPrint) SELECT _id, displayName, identifier, identityProvider, blocked, sortIndex, showFingerPrintUpgrade, useFingerPrint FROM identity;")
-                    execSQL("DROP TABLE identity;")
-                    execSQL("ALTER TABLE new_identity RENAME TO identity;")
-                    execSQL("CREATE UNIQUE INDEX id_idx ON identity(_id);")
-                    execSQL("CREATE INDEX identifier_idx ON identity(identifier);")
-                    execSQL("CREATE INDEX identity_provider_idx ON identity(identityProvider);")
-
-                    execSQL("CREATE TABLE new_identityprovider (_id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, displayName TEXT NOT NULL, identifier TEXT NOT NULL, authenticationUrl TEXT NOT NULL, ocraSuite TEXT NOT NULL, infoUrl TEXT, logo TEXT);")
-                    execSQL("INSERT INTO new_identityprovider (_id, displayName, identifier, authenticationUrl, ocraSuite, infoUrl, logo) SELECT _id, displayName, identifier, authenticationUrl, ocraSuite, infoUrl, logo FROM identityprovider;")
-                    execSQL("DROP TABLE identityprovider;")
-                    execSQL("ALTER TABLE new_identityprovider RENAME TO identityprovider;")
-                    execSQL("CREATE INDEX ip_identifier_idx ON identityprovider(identifier)")
-                }
-            }
-        }
-
-        @Deprecated("The migration from 8 to 9 is using a unique index on the identityprovider table which is wrong. Migrating to this version 9 can lead to data loss for users.")
-        val FROM_8_TO_9: Migration = object : Migration(8, 9) {
-            override fun migrate(database: SupportSQLiteDatabase) {
-                Timber.d("Migrating database from version $startVersion to version $endVersion.")
-                Timber.d("Renames fingerprint to biometric. Renames indexes.")
-
-                database.run {
-                    execSQL("CREATE TABLE new_identity (_id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, displayName TEXT NOT NULL, identifier TEXT NOT NULL, identityProvider INTEGER NOT NULL, blocked INTEGER NOT NULL DEFAULT 0, sortIndex INTEGER NOT NULL, biometricInUse INTEGER NOT NULL DEFAULT 0, biometricOfferUpgrade INTEGER NOT NULL DEFAULT 1, FOREIGN KEY(identityProvider) REFERENCES identityprovider(_id) ON UPDATE NO ACTION ON DELETE RESTRICT)")
-                    execSQL("INSERT INTO new_identity (_id, displayName, identifier, identityProvider, blocked, sortIndex, biometricInUse, biometricOfferUpgrade) SELECT _id, displayName, identifier, identityProvider, blocked, sortIndex, useFingerPrint, showFingerPrintUpgrade FROM identity;")
-                    execSQL("DROP TABLE identity;")
-                    execSQL("ALTER TABLE new_identity RENAME TO identity;")
-                    execSQL("CREATE UNIQUE INDEX index_identity_id ON identity(_id);")
-                    execSQL("CREATE INDEX index_identity_identifier ON identity(identifier);")
-                    execSQL("CREATE INDEX index_identity_identityProvider ON identity(identityProvider);")
-
-                    execSQL("DROP INDEX ip_identifier_idx;")
-                    execSQL("CREATE UNIQUE INDEX index_identityprovider_identifier ON identityprovider(identifier);")
-                }
-            }
-        }
-
-        val FROM_8_TO_10: Migration = object : Migration(8, 10) {
-            override fun migrate(database: SupportSQLiteDatabase) {
-                Timber.d("Migrating database from version $startVersion to version $endVersion.")
-                Timber.d("Renames fingerprint to biometric. Renames indexes. Creates non-unique index on identityprovider(identifier)")
-
-                database.run {
-                    execSQL("CREATE TABLE new_identity (_id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, displayName TEXT NOT NULL, identifier TEXT NOT NULL, identityProvider INTEGER NOT NULL, blocked INTEGER NOT NULL DEFAULT 0, sortIndex INTEGER NOT NULL, biometricInUse INTEGER NOT NULL DEFAULT 0, biometricOfferUpgrade INTEGER NOT NULL DEFAULT 1, FOREIGN KEY(identityProvider) REFERENCES identityprovider(_id) ON UPDATE NO ACTION ON DELETE RESTRICT)")
-                    execSQL("INSERT INTO new_identity (_id, displayName, identifier, identityProvider, blocked, sortIndex, biometricInUse, biometricOfferUpgrade) SELECT _id, displayName, identifier, identityProvider, blocked, sortIndex, useFingerPrint, showFingerPrintUpgrade FROM identity;")
-                    execSQL("DROP TABLE identity;")
-                    execSQL("ALTER TABLE new_identity RENAME TO identity;")
-                    execSQL("CREATE UNIQUE INDEX index_identity_id ON identity(_id)")
-                    execSQL("CREATE INDEX index_identity_identifier ON identity(identifier)")
-                    execSQL("CREATE INDEX index_identity_identityProvider ON identity(identityProvider)")
-
-                    execSQL("CREATE INDEX index_identityprovider_identifier ON identityprovider(identifier);")
-                }
-            }
-        }
-
-        /**
-         * For the apps that have already migrated to version 9 and have already experienced data loss, we still have to drop the unique index
-         * and create it as not unique.
-         * */
-        val FROM_9_TO_10: Migration = object : Migration(9, 10) {
-            override fun migrate(database: SupportSQLiteDatabase) {
-                Timber.d("Migrating database from version $startVersion to version $endVersion.")
-                Timber.d("Drops the unique index `index_identityprovider_identifier` and recreates it as not unique.")
-
-                database.run {
-                    execSQL("DROP INDEX index_identityprovider_identifier;")
-                    execSQL("CREATE INDEX index_identityprovider_identifier ON identityprovider(identifier);")
-                }
-            }
-        }
     }
 
     abstract fun tiqrDao(): TiqrDao

--- a/data/src/main/java/org/tiqr/data/model/IdentityProvider.kt
+++ b/data/src/main/java/org/tiqr/data/model/IdentityProvider.kt
@@ -41,7 +41,7 @@ import kotlinx.parcelize.Parcelize
  */
 @Entity(tableName = "identityprovider",
         indices = [
-                Index(value = ["identifier"], name = "index_identityprovider_identifier", unique = true)
+                Index(value = ["identifier"], name = "index_identityprovider_identifier", unique = false)
         ]
 )
 @Parcelize

--- a/data/src/main/java/org/tiqr/data/model/IdentityProvider.kt
+++ b/data/src/main/java/org/tiqr/data/model/IdentityProvider.kt
@@ -41,7 +41,7 @@ import kotlinx.parcelize.Parcelize
  */
 @Entity(tableName = "identityprovider",
         indices = [
-                Index(value = ["identifier"], name = "index_identityprovider_identifier", unique = false)
+                Index(value = ["identifier"], name = "index_identityprovider_identifier", unique = true)
         ]
 )
 @Parcelize

--- a/data/src/main/java/org/tiqr/data/module/PersistenceModule.kt
+++ b/data/src/main/java/org/tiqr/data/module/PersistenceModule.kt
@@ -36,7 +36,7 @@ import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.components.SingletonComponent
-import org.tiqr.data.database.TiqrDao
+import org.tiqr.data.database.*
 import org.tiqr.data.database.TiqrDatabase
 import javax.inject.Singleton
 
@@ -52,11 +52,7 @@ internal object PersistenceModule {
     internal fun provideTiqrDatabase(@ApplicationContext context: Context): TiqrDatabase =
         Room.databaseBuilder(context, TiqrDatabase::class.java, TiqrDatabase.DB_NAME)
             .addMigrations(
-                TiqrDatabase.FROM_4_TO_5,
-                TiqrDatabase.FROM_5_TO_7,
-                TiqrDatabase.FROM_7_TO_8,
-                TiqrDatabase.FROM_8_TO_10,
-                TiqrDatabase.FROM_9_TO_10,
+                *ALL_VALID_MIGRATIONS
             )
             .build()
 

--- a/data/src/main/java/org/tiqr/data/module/PersistenceModule.kt
+++ b/data/src/main/java/org/tiqr/data/module/PersistenceModule.kt
@@ -50,14 +50,15 @@ internal object PersistenceModule {
     @Provides
     @Singleton
     internal fun provideTiqrDatabase(@ApplicationContext context: Context): TiqrDatabase =
-            Room.databaseBuilder(context, TiqrDatabase::class.java, TiqrDatabase.DB_NAME)
-                    .addMigrations(
-                            TiqrDatabase.FROM_4_TO_5,
-                            TiqrDatabase.FROM_5_TO_7,
-                            TiqrDatabase.FROM_7_TO_8,
-                            TiqrDatabase.FROM_8_TO_9
-                    )
-                    .build()
+        Room.databaseBuilder(context, TiqrDatabase::class.java, TiqrDatabase.DB_NAME)
+            .addMigrations(
+                TiqrDatabase.FROM_4_TO_5,
+                TiqrDatabase.FROM_5_TO_7,
+                TiqrDatabase.FROM_7_TO_8,
+                TiqrDatabase.FROM_8_TO_10,
+                TiqrDatabase.FROM_9_TO_10,
+            )
+            .build()
 
     @Provides
     @Singleton

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -18,7 +18,7 @@ retrofit = "2.9.0"
 moshi = "1.14.0"
 
 [libraries]
-android-gradle = "com.android.tools.build:gradle:7.3.0"
+android-gradle = "com.android.tools.build:gradle:7.3.1"
 
 kotlin-stdlib = { module = "org.jetbrains.kotlin:kotlin-stdlib-jdk8", version.ref = "kotlin" }
 kotlin-gradle = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin" }


### PR DESCRIPTION
### Pull Request Checklist
- [x] I have added proper commit messages
- [x] I have updated tests and documentation
- [x] I ran the tests
- [x] I provided the ticket number as PR title
- [ ] I have assigned the required reviewers

### Short Description of Change
<!-- Please provide information regarding the change -->
```
Reverted the changes done for room version 9 as they have already been released & in used. Recreated those changes in version 10 and added android tests to check all migration paths for room (everything starting with version 8)
```

### Motivation and Context
<!-- Please provide why this change was required -->
```
Trying to mitigate data loss by providing an alternative migration path: from 8 directly to 10 without passing through version 9. According to the tests the data loss no longer happens when the user doesn't go through 9.
Providing remedial change for user that have already migrated to version 9 so that they can register multiple providers with the same provider identifier.
```

### Testing Steps
<!-- Please provide steps to test (manual/automation) to verify the change -->
```
App update path:
3.1.0-> 4.0.3 == data loss
3.1.0 ->  new version using new core  == no data loss
4.0.3 ->  new version using new core  == able to register multiple providers with the same provider identifier
```

### Additional Information
<!-- Please provide any additional information or screenshot -->
```
😄 
<img width="568" alt="Screenshot 2022-11-02 at 16 57 10" src="https://user-images.githubusercontent.com/2356050/199538655-4bd8bba9-92e3-4268-926e-b75bcf1d772b.png">

```