### PR TITLE
Update min SDK to 24 (Android 7)

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 android-sdk-compile = "33"
 android-sdk-target = "33"
-android-sdk-min = "23"
+android-sdk-min = "24"
 android-buildTools = "33.0.0"
 
 kotlin = "1.7.20"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 android-sdk-compile = "33"
 android-sdk-target = "33"
-android-sdk-min = "21"
+android-sdk-min = "23"
 android-buildTools = "33.0.0"
 
 kotlin = "1.7.20"


### PR DESCRIPTION
### Pull Request Checklist
- [x] I have added proper commit messages
- [x] I have updated tests and documentation
- [x] I ran the tests
- [x] I provided the ticket number as PR title
- [x] I have assigned the required reviewers

### Short Description of Change
Update minSDK to 24 (Android 7)

### Motivation and Context
Due to security risks & Android versions no longer receiving updates the min SDK is updated to Android 7.

### Testing Steps
Be able to install the app on Android 7, but not on lower Android devices.

### Additional Information
Breaking change: When apps use this new core they also need to update their own `minSDK` value.
When publishing the apps to google play the console will prompt that a number of devices will no longer be supported. This is a consequence of dropping the lower versions of Android.