### PR TITLE
TIQR-301: Add domain information on the enrollment confirmed screen

### DIFF
--- a/core/src/main/res/layout/fragment_enrollment_summary.xml
+++ b/core/src/main/res/layout/fragment_enrollment_summary.xml
@@ -32,8 +32,8 @@
             android:layout_marginTop="48dp"
             android:text="@string/enroll_confirm_details"
             android:textStyle="italic"
-            app:layout_constraintTop_toBottomOf="@id/title"
-            app:layout_constraintStart_toStartOf="parent" />
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/title" />
 
         <androidx.constraintlayout.helper.widget.Flow
             android:id="@id/table"
@@ -41,7 +41,7 @@
             android:layout_height="wrap_content"
             android:layout_marginBottom="16dp"
             android:orientation="horizontal"
-            app:constraint_referenced_ids="label_name, name, label_id, id"
+            app:constraint_referenced_ids="label_name, name, label_id, id, spacer, label_domain, domain"
             app:flow_horizontalGap="4dp"
             app:flow_horizontalStyle="spread_inside"
             app:flow_maxElementsWrap="2"
@@ -99,6 +99,28 @@
             app:layout_constraintWidth_default="spread"
             tools:ignore="MissingConstraints,UnusedAttribute"
             tools:text="&lt;identity identifier&gt;" />
+
+        <Space
+            android:id="@+id/spacer"
+            android:layout_width="match_parent"
+            android:layout_height="20dp"
+            tools:ignore="MissingConstraints" />
+
+        <TextView
+            android:id="@+id/label_domain"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="@string/enroll_confirm_domain"
+            tools:ignore="MissingConstraints" />
+
+        <TextView
+            android:id="@+id/domain"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="@{viewModel.challenge.enrollmentHost}"
+            android:textAppearance="@style/AppTheme.TextAppearance.Label"
+            tools:ignore="MissingConstraints"
+            tools:text="&lt;enrollment url domain&gt;" />
 
         <Button
             android:id="@+id/button_ok"


### PR DESCRIPTION
### Pull Request Checklist
- [X] I have added proper commit messages
- [X] I have updated tests and documentation
- [X] I ran the tests
- [X] I provided the ticket number as PR title
- [X] I have assigned the required reviewers

### Short Description of Change
After the enrollment is done, the domain is missing on the confirmation screen.

### Motivation and Context
Adding the domain information on the screen confirming the account activation.
### Testing Steps
Enroll a new user
On the account activated screen, check to see the domain is visible.

### Additional Information
![image](https://user-images.githubusercontent.com/2356050/202482607-6c1b3edd-a502-41ac-b192-435749441da6.png)
