### PR TITLE
Override actionbar-theme. Prepare for dark theme

### DIFF
--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -7,4 +7,7 @@
 
     <color name="white">#FFFFFF</color>
     <color name="grey_50">#FAFAFA</color>
+
+    <color name="actionbarBackground">#0002e4</color>
+
 </resources>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -15,6 +15,11 @@
         <item name="android:textColorLink">@color/linkColor</item>
         <item name="android:textViewStyle">@style/AppTheme.TextView</item>
         <item name="materialCardViewStyle">@style/AppTheme.Card</item>
+        <item name="actionBarTheme">@style/TiqrActionBar</item>
+    </style>
+
+    <style name="TiqrActionBar" parent="@style/ThemeOverlay.MaterialComponents.ActionBar">
+        <item name="android:background">@color/actionbarBackground</item>
     </style>
 
     <style name="AppTheme.Splash" parent="Theme.SplashScreen">

--- a/core/src/main/res/layout/activity_main.xml
+++ b/core/src/main/res/layout/activity_main.xml
@@ -23,7 +23,7 @@
                 android:id="@+id/toolbar"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:theme="@style/ThemeOverlay.MaterialComponents.ActionBar" >
+                android:theme="@style/TiqrActionBar" >
 
                 <ImageView
                     android:layout_gravity="center"

--- a/core/src/main/res/values-night/colors.xml
+++ b/core/src/main/res/values-night/colors.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <color name="actionbarBackground">#000000</color>
+</resources>

--- a/core/src/main/res/values/colors.xml
+++ b/core/src/main/res/values/colors.xml
@@ -12,4 +12,6 @@
 
     <color name="white">#FFFFFF</color>
     <color name="grey_50">#FAFAFA</color>
+
+    <color name="actionbarBackground">#ABBD26</color>
 </resources>

--- a/core/src/main/res/values/styles.xml
+++ b/core/src/main/res/values/styles.xml
@@ -16,6 +16,11 @@
         <item name="android:textColorLink">@color/linkColor</item>
         <item name="android:textViewStyle">@style/AppTheme.TextView</item>
         <item name="materialCardViewStyle">@style/AppTheme.Card</item>
+        <item name="actionBarTheme">@style/TiqrActionBar</item>
+    </style>
+
+    <style name="TiqrActionBar" parent="@style/ThemeOverlay.MaterialComponents.ActionBar">
+        <item name="android:background">@color/actionbarBackground</item>
     </style>
 
     <style name="AppTheme.Splash" parent="Theme.SplashScreen">


### PR DESCRIPTION
### Pull Request Checklist
- [x] I have added proper commit messages
- [ ] I have updated tests and documentation
- [ ] I ran the tests
- [ ] I provided the ticket number as PR title
- [x] I have assigned the required reviewers

### Short Description of Change
<!-- Please provide information regarding the change -->
```
To allow adding a dark theme, the actionbar theme must be overwritten. This adds a color-name to change the actionbar color in the different apps, zo we can add dark mode in them.
```

