### PR TITLE
TIQR-326: Fix for after removing an account, no account details can be opened

### DIFF
--- a/core/src/main/java/org/tiqr/core/identity/IdentityDetailFragment.kt
+++ b/core/src/main/java/org/tiqr/core/identity/IdentityDetailFragment.kt
@@ -33,16 +33,16 @@ import android.os.Bundle
 import android.view.View
 import androidx.annotation.LayoutRes
 import androidx.hilt.navigation.fragment.hiltNavGraphViewModels
-import androidx.navigation.fragment.navArgs
-import org.tiqr.core.R
-import org.tiqr.core.databinding.FragmentIdentityDetailBinding
-import org.tiqr.data.viewmodel.IdentityViewModel
 import androidx.navigation.fragment.findNavController
+import androidx.navigation.fragment.navArgs
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import dagger.hilt.android.AndroidEntryPoint
+import org.tiqr.core.R
 import org.tiqr.core.base.BaseFragment
+import org.tiqr.core.databinding.FragmentIdentityDetailBinding
 import org.tiqr.core.util.extensions.biometricUsable
 import org.tiqr.data.model.Identity
+import org.tiqr.data.viewmodel.IdentityViewModel
 
 /**
  * Fragment to display the [Identity] details
@@ -79,12 +79,18 @@ class IdentityDetailFragment : BaseFragment<FragmentIdentityDetailBinding>() {
         }
 
         binding.buttonDelete.setOnClickListener {
-            MaterialAlertDialogBuilder(requireContext())
-                    .setTitle(R.string.identity_delete_title)
-                    .setMessage(R.string.identity_delete_message)
-                    .setNegativeButton(R.string.button_cancel) { dialog, _ -> dialog.dismiss() }
-                    .setPositiveButton(R.string.button_delete) { _, _ -> viewModel.deleteIdentity(args.identity.identity) }
-                    .show()
+            MaterialAlertDialogBuilder(requireContext()).setTitle(R.string.identity_delete_title)
+                .setMessage(R.string.identity_delete_message)
+                .setNegativeButton(R.string.button_cancel) { dialog, _ -> dialog.dismiss() }
+                .setPositiveButton(R.string.button_delete) { _, _ ->
+                    deleteAndClose()
+                }.show()
         }
     }
+
+    private fun deleteAndClose() {
+        viewModel.deleteIdentity(args.identity.identity)
+        findNavController().popBackStack()
+    }
+
 }

--- a/data/src/main/java/org/tiqr/data/viewmodel/IdentityViewModel.kt
+++ b/data/src/main/java/org/tiqr/data/viewmodel/IdentityViewModel.kt
@@ -41,7 +41,8 @@ import javax.inject.Inject
  * ViewModel for the identity screens (list & detail).
  */
 @HiltViewModel
-class IdentityViewModel @Inject constructor(private val repository: IdentityRepository) : ViewModel() {
+class IdentityViewModel @Inject constructor(private val repository: IdentityRepository) :
+    ViewModel() {
     private val identifier = MutableLiveData<String>()
     val identities = repository.allIdentities().asLiveData(viewModelScope.coroutineContext)
     val identity: LiveData<IdentityWithProvider?> = identifier.switchMap {


### PR DESCRIPTION
Ensure that the accounts details screen doesn't work with stale data: after the delete account operation is started (as a fire & forget), immediately close the detail screen. This ensures the details screen won't fire it's automatic close screen when the data is gone and get stuck there. It gets stuck because the view model lifecycle is tied to the navigation graph and as long as the identities list screen remains open, the identities details view model will "remember" it's last identity details were null. Ergo, subsequently trying to open the details screen will immediately trigger closing the detail screen

### Pull Request Checklist
- [x] I have added proper commit messages
- [ ] I have updated tests and documentation
- [ ] I ran the tests
- [x] I provided the ticket number as PR title
- [ ] I have assigned the required reviewers

### Short Description of Change
Ensure that the accounts details screen doesn't work with stale data: after the delete account operation is started (as a fire & forget), immediately close the detail screen. This ensures the details screen won't fire it's automatic close screen when the data is gone and get stuck there. It gets stuck because the view model lifecycle is tied to the navigation graph and as long as the identities list screen remains open, the identities details view model will "remember" it's last identity details were null. Ergo, subsequently trying to open the details screen will immediately trigger closing the detail screen

### Motivation and Context

### Testing Steps
Have multiple accounts enrolled.
Open one account detail and delete it from the detail screen.
Try to open another account detail.

### Additional Information
