### PR TITLE
TIQR-339: black screen on QR-code scanner (Samsung A23)

### DIFF
--- a/core/src/main/java/org/tiqr/core/scan/ScanAnalyzer.kt
+++ b/core/src/main/java/org/tiqr/core/scan/ScanAnalyzer.kt
@@ -57,16 +57,12 @@ class ScanAnalyzer(
         private val result: (String) -> Unit
 ) : ImageAnalysis.Analyzer {
     private val lifecycleScope = lifecycleOwner.lifecycleScope
-    private val detector: BarcodeScanner
-
-    init {
-        detector = BarcodeScannerOptions.Builder()
-                .setBarcodeFormats(Barcode.FORMAT_QR_CODE)
-                .build()
-                .run {
-                    BarcodeScanning.getClient(this)
-                }
-    }
+    private val detector: BarcodeScanner = BarcodeScannerOptions.Builder()
+            .setBarcodeFormats(Barcode.FORMAT_QR_CODE)
+            .build()
+            .run {
+                BarcodeScanning.getClient(this)
+            }
 
     @ExperimentalGetImage
     override fun analyze(image: ImageProxy) {

--- a/core/src/main/java/org/tiqr/core/scan/ScanComponent.kt
+++ b/core/src/main/java/org/tiqr/core/scan/ScanComponent.kt
@@ -60,11 +60,11 @@ import kotlin.math.min
  * The processing of the camera image to a QR code is delegated to [ScanAnalyzer].
  */
 class ScanComponent(
-        private val context: Context,
-        private val lifecycleOwner: LifecycleOwner,
-        private val viewFinder: PreviewView,
-        private val viewFinderRatio: Float,
-        private val scanResult: (result: String) -> Unit
+    private val context: Context,
+    private val lifecycleOwner: LifecycleOwner,
+    private val viewFinder: PreviewView,
+    viewFinderRatio: Float,
+    private val scanResult: (result: String) -> Unit,
 ) : DefaultLifecycleObserver {
     companion object {
         private const val BEEP_VOLUME = 0.1f
@@ -97,7 +97,7 @@ class ScanComponent(
     private val lifecycleScope = lifecycleOwner.lifecycleScope
 
     private val broadcastManager: LocalBroadcastManager = LocalBroadcastManager.getInstance(context)
-    private val keyReceiver = ScanKeyEventsReceiver { enable -> camera.cameraControl.enableTorch(enable) }
+    private val keyReceiver = ScanKeyEventsReceiver { enable -> toggleTorch(enable) }
 
     init {
         lifecycleOwner.lifecycle.addObserver(this)
@@ -111,9 +111,18 @@ class ScanComponent(
     /**
      * Initialize the [ProcessCameraProvider]
      */
-    private suspend fun initCameraProvider(): ProcessCameraProvider {
-        return withContext(Dispatchers.Default) {
+    private suspend fun initCameraProvider(): ProcessCameraProvider =
+        withContext(Dispatchers.Default) {
             ProcessCameraProvider.getInstance(context).await()
+        }
+
+    /**
+     * Allow toggling the torch for the camera from outside the library component.
+     * */
+    @Suppress("MemberVisibilityCanBePrivate")
+    fun toggleTorch(enable: Boolean) {
+        if (this::camera.isInitialized) {
+            camera.cameraControl.enableTorch(enable)
         }
     }
 

--- a/core/src/main/java/org/tiqr/core/scan/ScanFragment.kt
+++ b/core/src/main/java/org/tiqr/core/scan/ScanFragment.kt
@@ -60,10 +60,10 @@ class ScanFragment : BaseFragment<FragmentScanBinding>() {
 
         binding.viewFinder.doOnLayout {
             scanComponent = ScanComponent(
-                    context = requireContext(),
-                    lifecycleOwner = viewLifecycleOwner,
-                    viewFinder = binding.viewFinder,
-                    viewFinderRatio = it.height.toFloat() / it.width.toFloat()
+                context = requireContext(),
+                lifecycleOwner = viewLifecycleOwner,
+                viewFinder = binding.viewFinder,
+                viewFinderRatio = it.height.toFloat() / it.width.toFloat()
             ) { result ->
                 binding.progress.show()
                 viewModel.parseChallenge(result)

--- a/data/src/main/java/org/tiqr/data/model/Challenge.kt
+++ b/data/src/main/java/org/tiqr/data/model/Challenge.kt
@@ -30,6 +30,7 @@
 package org.tiqr.data.model
 
 import android.os.Parcelable
+import com.squareup.moshi.JsonClass
 import kotlinx.parcelize.Parcelize
 import org.tiqr.data.BuildConfig
 
@@ -47,6 +48,7 @@ sealed class Challenge {
  * The result for the [EnrollmentChallenge]
  */
 @Parcelize
+@JsonClass(generateAdapter = true)
 data class EnrollmentChallenge(
         override val protocolVersion: Int = TiqrConfig.protocolVersion,
         override val identityProvider: IdentityProvider,
@@ -60,6 +62,7 @@ data class EnrollmentChallenge(
  * The result for the [AuthenticationChallenge]
  */
 @Parcelize
+@JsonClass(generateAdapter = true)
 data class AuthenticationChallenge(
         override val protocolVersion: Int = TiqrConfig.protocolVersion,
         override val identityProvider: IdentityProvider,

--- a/data/src/main/java/org/tiqr/data/model/Identity.kt
+++ b/data/src/main/java/org/tiqr/data/model/Identity.kt
@@ -31,6 +31,7 @@ package org.tiqr.data.model
 
 import android.os.Parcelable
 import androidx.room.*
+import com.squareup.moshi.JsonClass
 import kotlinx.parcelize.Parcelize
 
 /**
@@ -51,7 +52,9 @@ import kotlinx.parcelize.Parcelize
                 )
         ]
 )
+
 @Parcelize
+@JsonClass(generateAdapter = true)
 data class Identity(
         @PrimaryKey(autoGenerate = true)
         @ColumnInfo(name = "_id")

--- a/data/src/main/java/org/tiqr/data/model/IdentityProvider.kt
+++ b/data/src/main/java/org/tiqr/data/model/IdentityProvider.kt
@@ -34,6 +34,7 @@ import androidx.room.ColumnInfo
 import androidx.room.Entity
 import androidx.room.Index
 import androidx.room.PrimaryKey
+import com.squareup.moshi.JsonClass
 import kotlinx.parcelize.Parcelize
 
 /**
@@ -45,6 +46,7 @@ import kotlinx.parcelize.Parcelize
         ]
 )
 @Parcelize
+@JsonClass(generateAdapter = true)
 data class IdentityProvider(
         @PrimaryKey(autoGenerate = true)
         @ColumnInfo(name = "_id")

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -4,21 +4,21 @@ android-sdk-target = "33"
 android-sdk-min = "24"
 android-buildTools = "33.0.0"
 
-kotlin = "1.7.20"
+kotlin = "1.8.0"
 coroutines = "1.6.4"
 
 hilt = "2.44"
 navigation = "2.5.3"
 room = "2.5.0-beta01"
 lifecycle = "2.5.1"
-camera = "1.2.0-rc01"
+camera = "1.3.0-alpha03"
 
 okhttp = "4.9.2"
 retrofit = "2.9.0"
 moshi = "1.14.0"
 
 [libraries]
-android-gradle = "com.android.tools.build:gradle:7.3.1"
+android-gradle = "com.android.tools.build:gradle:7.4.0"
 
 kotlin-stdlib = { module = "org.jetbrains.kotlin:kotlin-stdlib-jdk8", version.ref = "kotlin" }
 kotlin-gradle = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin" }


### PR DESCRIPTION
### Pull Request Checklist

### Short Description of Change
Fix for TIQR-339: Black screen on QR-code scanner (Samsung A23)
Changes for redesign reusability.
### Motivation and Context
Black screen when trying to use the camera happens when the camera preview fails to sets the `SurfaceProvider`. The alpha version includes fixes for this: https://android-review.googlesource.com/#/q/Ib3f27c45c8ad1f9fc837454961a27087fe2f38ff
Using the alpha version requires Kotlin 1.8.

No impact for existing integrations: Exposing functionality for reuse in redesign work.
Ensure that the camera flashlight may be turned out from outside the library.
Allow the challenge parameter types to be used in compose navigation which only allows passing them as URL encoded strings.

### Testing Steps
This wasn't reproducible outside of dev environment. Revisit after release and check if the issue re-appears.

### Additional Information
