### PR TITLE
TIQR-335: Ensure the correct AuthenticationChallenge arguments are passed to all screens that require them

### DIFF
--- a/core/src/main/java/org/tiqr/core/authentication/AuthenticationBiometricFragment.kt
+++ b/core/src/main/java/org/tiqr/core/authentication/AuthenticationBiometricFragment.kt
@@ -55,14 +55,14 @@ class AuthenticationBiometricFragment : BaseFragment<FragmentAuthenticationBiome
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
-        viewModel.authenticate.observe(viewLifecycleOwner) {
+        viewModel.authenticate.observe(viewLifecycleOwner) { it ->
             binding.progress.hide()
 
             when (it) {
                 is ChallengeCompleteResult.Success -> {
-                    viewModel.challenge.value?.let {
+                    viewModel.challenge.value?.let { challenge ->
                         findNavController().navigate(
-                            AuthenticationPinFragmentDirections.actionSummary(it)
+                            AuthenticationPinFragmentDirections.actionSummary(challenge)
                         )
                     }
                 }
@@ -72,11 +72,13 @@ class AuthenticationBiometricFragment : BaseFragment<FragmentAuthenticationBiome
                         when (failure.reason) {
                             AuthenticationCompleteFailure.Reason.UNKNOWN,
                             AuthenticationCompleteFailure.Reason.CONNECTION -> {
-                                findNavController().navigate(
-                                    AuthenticationBiometricFragmentDirections.actionFallback(
-                                        SecretType.BIOMETRIC.key
+                                viewModel.challenge.value?.let { challenge ->
+                                    findNavController().navigate(
+                                        AuthenticationBiometricFragmentDirections.actionFallback(
+                                            pin = SecretType.BIOMETRIC.key, challenge = challenge
+                                        )
                                     )
-                                )
+                                }
                             }
                             AuthenticationCompleteFailure.Reason.INVALID_RESPONSE -> {
                                 val remaining = failure.remainingAttempts
@@ -119,11 +121,23 @@ class AuthenticationBiometricFragment : BaseFragment<FragmentAuthenticationBiome
                 )
                 is AuthenticationBiometricComponent.BiometricResult.Cancel -> {
                     binding.progress.hide()
-                    findNavController().navigate(AuthenticationBiometricFragmentDirections.actionPin())
+                    viewModel.challenge.value?.let { challenge ->
+                        findNavController().navigate(
+                            AuthenticationBiometricFragmentDirections.actionPin(
+                                challenge
+                            )
+                        )
+                    }
                 }
                 is AuthenticationBiometricComponent.BiometricResult.Fail -> {
                     binding.progress.hide()
-                    findNavController().navigate(AuthenticationBiometricFragmentDirections.actionPin())
+                    viewModel.challenge.value?.let { challenge ->
+                        findNavController().navigate(
+                            AuthenticationBiometricFragmentDirections.actionPin(
+                                challenge
+                            )
+                        )
+                    }
                 }
             }
         }.run {

--- a/core/src/main/java/org/tiqr/core/authentication/AuthenticationConfirmFragment.kt
+++ b/core/src/main/java/org/tiqr/core/authentication/AuthenticationConfirmFragment.kt
@@ -50,7 +50,6 @@ import org.tiqr.data.viewmodel.AuthenticationViewModel
 @AndroidEntryPoint
 class AuthenticationConfirmFragment : BaseFragment<FragmentAuthenticationConfirmBinding>() {
     private val viewModel by hiltNavGraphViewModels<AuthenticationViewModel>(R.id.authentication_nav)
-    private val args by navArgs<AuthenticationConfirmFragmentArgs>()
 
     @LayoutRes
     override val layout = R.layout.fragment_authentication_confirm
@@ -63,6 +62,7 @@ class AuthenticationConfirmFragment : BaseFragment<FragmentAuthenticationConfirm
                 setHasOptionsMenu(true)
                 findNavController().navigate(
                     AuthenticationConfirmFragmentDirections.actionIdentity(
+                        challenge = challenge,
                         cancellable = false
                     )
                 )
@@ -86,10 +86,20 @@ class AuthenticationConfirmFragment : BaseFragment<FragmentAuthenticationConfirm
         }
 
         binding.buttonOk.setOnClickListener {
-            if (viewModel.challenge.value?.identity?.biometricInUse == true) {
-                findNavController().navigate(AuthenticationConfirmFragmentDirections.actionBiometric())
-            } else {
-                findNavController().navigate(AuthenticationConfirmFragmentDirections.actionPin())
+            viewModel.challenge.value?.let { challenge ->
+                if (viewModel.challenge.value?.identity?.biometricInUse == true) {
+                    findNavController().navigate(
+                        AuthenticationConfirmFragmentDirections.actionBiometric(
+                            challenge
+                        )
+                    )
+                } else {
+                    findNavController().navigate(
+                        AuthenticationConfirmFragmentDirections.actionPin(
+                            challenge
+                        )
+                    )
+                }
             }
         }
     }
@@ -97,11 +107,14 @@ class AuthenticationConfirmFragment : BaseFragment<FragmentAuthenticationConfirm
     override fun onOptionsItemSelected(item: MenuItem): Boolean {
         return when (item.itemId) {
             R.id.identity_pick -> {
-                findNavController().navigate(
-                    AuthenticationConfirmFragmentDirections.actionIdentity(
-                        cancellable = true
+                viewModel.challenge.value?.let { challenge ->
+                    findNavController().navigate(
+                        AuthenticationConfirmFragmentDirections.actionIdentity(
+                            challenge = challenge,
+                            cancellable = true
+                        )
                     )
-                )
+                }
                 true
             }
             else -> super.onOptionsItemSelected(item)

--- a/core/src/main/java/org/tiqr/core/authentication/AuthenticationFallbackFragment.kt
+++ b/core/src/main/java/org/tiqr/core/authentication/AuthenticationFallbackFragment.kt
@@ -31,6 +31,7 @@ package org.tiqr.core.authentication
 
 import android.os.Bundle
 import android.view.View
+import androidx.hilt.navigation.fragment.hiltNavGraphViewModels
 import androidx.navigation.fragment.findNavController
 import androidx.navigation.fragment.navArgs
 import androidx.navigation.navGraphViewModels
@@ -47,7 +48,7 @@ import org.tiqr.data.viewmodel.AuthenticationViewModel
  */
 @AndroidEntryPoint
 class AuthenticationFallbackFragment : BaseFragment<FragmentAuthenticationFallbackBinding>() {
-    private val viewModel by navGraphViewModels<AuthenticationViewModel>(R.id.authentication_nav)
+    private val viewModel by hiltNavGraphViewModels<AuthenticationViewModel>(R.id.authentication_nav)
     private val args by navArgs<AuthenticationFallbackFragmentArgs>()
 
     override val layout = R.layout.fragment_authentication_fallback
@@ -68,9 +69,9 @@ class AuthenticationFallbackFragment : BaseFragment<FragmentAuthenticationFallba
             when (it) {
                 is ChallengeCompleteOtpResult.Failure -> {
                     MaterialAlertDialogBuilder(requireContext())
-                            .setTitle(it.failure.title)
-                            .setMessage(it.failure.message)
-                            .show()
+                        .setTitle(it.failure.title)
+                        .setMessage(it.failure.message)
+                        .show()
                 }
                 else -> {
                     // Handled inside binding

--- a/core/src/main/java/org/tiqr/core/authentication/AuthenticationPinFragment.kt
+++ b/core/src/main/java/org/tiqr/core/authentication/AuthenticationPinFragment.kt
@@ -83,9 +83,14 @@ class AuthenticationPinFragment : BaseFragment<FragmentAuthenticationPinBinding>
                         when (failure.reason) {
                             AuthenticationCompleteFailure.Reason.UNKNOWN,
                             AuthenticationCompleteFailure.Reason.CONNECTION -> {
-                                findNavController().navigate(
-                                    AuthenticationPinFragmentDirections.actionFallback(binding.pin.currentPin)
-                                )
+                                viewModel.challenge.value?.let { challenge ->
+                                    findNavController().navigate(
+                                        AuthenticationPinFragmentDirections.actionFallback(
+                                            pin = binding.pin.currentPin,
+                                            challenge = challenge
+                                        )
+                                    )
+                                }
                             }
                             AuthenticationCompleteFailure.Reason.INVALID_RESPONSE -> {
                                 val remaining = failure.remainingAttempts

--- a/core/src/main/java/org/tiqr/core/authentication/AuthenticationPinFragment.kt
+++ b/core/src/main/java/org/tiqr/core/authentication/AuthenticationPinFragment.kt
@@ -104,9 +104,11 @@ class AuthenticationPinFragment : BaseFragment<FragmentAuthenticationPinBinding>
                                     .setPositiveButton(R.string.button_ok) { dialog, _ ->
                                         if (remaining != null && remaining == 0) {
                                             // Blocked. Pop back to start.
+                                            dialog.dismiss()
                                             findNavController().popBackStack()
+                                        } else {
+                                            dialog.dismiss()
                                         }
-                                        dialog.dismiss()
                                     }
                                     .show()
                             }

--- a/core/src/main/java/org/tiqr/core/enrollment/EnrollmentPinVerifyFragment.kt
+++ b/core/src/main/java/org/tiqr/core/enrollment/EnrollmentPinVerifyFragment.kt
@@ -42,6 +42,7 @@ import org.tiqr.core.base.BaseFragment
 import org.tiqr.core.databinding.FragmentEnrollmentPinVerifyBinding
 import org.tiqr.core.util.extensions.biometricUsable
 import org.tiqr.data.model.ChallengeCompleteResult
+import org.tiqr.data.model.EnrollmentCompleteFailure
 import org.tiqr.data.viewmodel.EnrollmentViewModel
 
 /**
@@ -93,9 +94,15 @@ class EnrollmentPinVerifyFragment : BaseFragment<FragmentEnrollmentPinVerifyBind
                     }
                 }
                 is ChallengeCompleteResult.Failure -> {
+                    val failure = it.failure
+                    val reason = if (failure is EnrollmentCompleteFailure) {
+                        "(${failure.reason.name})"
+                    } else {
+                        ""
+                    }
                     MaterialAlertDialogBuilder(requireContext())
-                        .setTitle(it.failure.title)
-                        .setMessage(it.failure.message)
+                        .setTitle(failure.title)
+                        .setMessage(failure.message + reason)
                         .setPositiveButton(R.string.button_ok) { dialog, _ -> dialog.dismiss() }
                         .show()
                 }

--- a/core/src/main/res/navigation/nav_graph.xml
+++ b/core/src/main/res/navigation/nav_graph.xml
@@ -83,12 +83,21 @@
                 android:name="cancellable"
                 android:defaultValue="false"
                 app:argType="boolean" />
+            <argument
+                android:name="challenge"
+                app:argType="org.tiqr.data.model.AuthenticationChallenge"
+                app:nullable="false" />
         </dialog>
 
         <fragment
             android:id="@+id/authentication_biometric"
             android:name="org.tiqr.core.authentication.AuthenticationBiometricFragment"
             tools:layout="@layout/fragment_authentication_biometric">
+
+            <argument
+                android:name="challenge"
+                app:argType="org.tiqr.data.model.AuthenticationChallenge"
+                app:nullable="false" />
 
             <action
                 android:id="@+id/action_summary"
@@ -114,6 +123,11 @@
             android:name="org.tiqr.core.authentication.AuthenticationPinFragment"
             tools:layout="@layout/fragment_authentication_pin">
 
+            <argument
+                android:name="challenge"
+                app:argType="org.tiqr.data.model.AuthenticationChallenge"
+                app:nullable="false" />
+
             <action
                 android:id="@+id/action_summary"
                 app:destination="@id/authentication_summary"
@@ -135,6 +149,11 @@
             <argument
                 android:name="pin"
                 app:argType="string" />
+            <argument
+                android:name="challenge"
+                app:argType="org.tiqr.data.model.AuthenticationChallenge"
+                app:nullable="false" />
+
         </fragment>
 
         <fragment


### PR DESCRIPTION
### Short Description of Change
Fix for TIQR-335, changes for TIQR-334 & TIQR-336
### Motivation and Context
TIQR-335: Fix for Exception java.lang.RuntimeException:
  at androidx.lifecycle.ViewModelProvider$NewInstanceFactory.create (ViewModelProvider.java)
  at androidx.lifecycle.ViewModelProvider$AndroidViewModelFactory.create (ViewModelProvider.java)
  at androidx.lifecycle.ViewModelProvider$AndroidViewModelFactory.create (ViewModelProvider.java)
  at androidx.lifecycle.ViewModelProvider$AndroidViewModelFactory.create (ViewModelProvider.java)
Related to TIQR-317, ensure all destination fragments using the AuthenticationViewModel correctly receive the AuthenticationChallenge argument.

TIQR-334: Add reason for failure in enrolment error dialog message.
TIQR-336: Ensure error dialog is dismissed when authentication fails before navigating back.

### Testing Steps
TIQR-335 can be tested the same way TIQR-317 was tested but putting the following screens in the background and killing the app:
Authentication fallback (i.e. connection was lost before completing authentication)
Authentication with PIN
Authentication with biometric

### Additional Information
Not able to reproduce TIQR-334 & TIQR-336.