### PR TITLE
Bugfix/tiqr 334 invalid enrolment security data debug

### DIFF
--- a/core/src/main/java/org/tiqr/core/about/AboutFragment.kt
+++ b/core/src/main/java/org/tiqr/core/about/AboutFragment.kt
@@ -29,10 +29,23 @@
 
 package org.tiqr.core.about
 
+import android.content.ClipData
+import android.content.ClipboardManager
+import android.content.Context
+import android.content.Context.CLIPBOARD_SERVICE
+import android.content.Intent
+import android.content.pm.PackageManager
+import android.net.Uri
+import android.os.Build
+import android.os.Bundle
+import android.view.View
+import android.widget.Toast
 import androidx.annotation.LayoutRes
 import org.tiqr.core.R
 import org.tiqr.core.base.BaseFragment
 import org.tiqr.core.databinding.FragmentAboutBinding
+import java.security.Security
+
 
 /**
  * Fragment to show the about screen.
@@ -40,4 +53,56 @@ import org.tiqr.core.databinding.FragmentAboutBinding
 class AboutFragment : BaseFragment<FragmentAboutBinding>() {
     @LayoutRes
     override val layout = R.layout.fragment_about
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        val capabilities = generateSecurityCapabilities()
+        binding.security.setOnClickListener {
+            sendEmail(it.context, capabilities)
+        }
+        val clipboardManager: ClipboardManager =
+            requireActivity().getSystemService(CLIPBOARD_SERVICE) as ClipboardManager
+        binding.security.setOnLongClickListener { it ->
+            clipboardManager.setPrimaryClip(ClipData.newPlainText("Copied", capabilities))
+            Toast.makeText(it.context, R.string.about_copied, Toast.LENGTH_SHORT).show()
+            true
+        }
+        binding.securityData.text = capabilities
+    }
+
+    private fun sendEmail(context: Context, emailBody: String) {
+        val versionName = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            context.packageManager.getPackageInfo(
+                context.packageName, PackageManager.PackageInfoFlags.of(0)
+            ).versionName
+        } else {
+            context.packageManager.getPackageInfo(
+                context.packageName, 0
+            ).versionName
+        }
+        val appName = getString(R.string.app_name)
+        val title = getString(R.string.about_label_version, appName, versionName)
+
+        val uri = Uri.parse("mailto:tiqr@surf.nl")
+            .buildUpon()
+            .appendQueryParameter("to", "tiqr@surf.nl")
+            .appendQueryParameter("subject", title)
+            .appendQueryParameter("body", emailBody)
+            .build()
+        val intent = Intent(Intent.ACTION_SENDTO, uri)
+        startActivity(Intent.createChooser(intent, "Send Email"))
+    }
+
+    private fun generateSecurityCapabilities(): String {
+        val capabilities = StringBuilder()
+        val providers = Security.getProviders()
+        providers.forEach { provider ->
+            capabilities.append("Provider ${provider.name}/${provider.version}. Services:\n")
+            provider.services.forEachIndexed { index, service ->
+                capabilities.append("\t$index. ${service.type} - ${service.algorithm}\n")
+            }
+            capabilities.append("End provider ${provider.name}/${provider.version}\n")
+        }
+        return capabilities.toString()
+    }
 }

--- a/core/src/main/res/layout/fragment_about.xml
+++ b/core/src/main/res/layout/fragment_about.xml
@@ -151,17 +151,24 @@
                 android:focusable="true"
                 app:cardElevation="6dp">
 
-                <TextView
+                <LinearLayout
                     android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:gravity="center_horizontal"
-                    android:text="@string/about_label_security_capabilities"
-                    android:textAppearance="@style/AppTheme.TextAppearance.Label" />
+                    android:layout_height="match_parent"
+                    android:orientation="vertical">
 
-                <TextView
-                    android:id="@+id/security_data"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content" />
+                    <TextView
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:gravity="center_horizontal"
+                        android:text="@string/about_label_security_capabilities"
+                        android:textAppearance="@style/AppTheme.TextAppearance.Label" />
+
+                    <TextView
+                        android:id="@+id/security_data"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        tools:text="Sample capabilities" />
+                </LinearLayout>
             </com.google.android.material.card.MaterialCardView>
 
         </LinearLayout>

--- a/core/src/main/res/layout/fragment_about.xml
+++ b/core/src/main/res/layout/fragment_about.xml
@@ -5,6 +5,7 @@
     tools:context="org.tiqr.core.about.AboutFragment">
 
     <data>
+
         <import type="org.tiqr.core.util.Urls" />
     </data>
 
@@ -34,10 +35,10 @@
                 app:openBrowser="@{@string/app_url}">
 
                 <LinearLayout
-                    android:orientation="vertical"
-                    android:layout_marginBottom="15dp"
                     android:layout_width="match_parent"
-                    android:layout_height="wrap_content">
+                    android:layout_height="wrap_content"
+                    android:layout_marginBottom="15dp"
+                    android:orientation="vertical">
 
                     <TextView
                         android:id="@+id/app_version_text"
@@ -51,11 +52,11 @@
                         tools:text="tiqr &#8226; v4.0.0" />
 
                     <ImageView
-                        android:adjustViewBounds="true"
-                        android:layout_gravity="center_horizontal"
                         style="@style/AboutAppIcon"
                         android:layout_width="120dp"
-                        android:layout_height="wrap_content"/>
+                        android:layout_height="wrap_content"
+                        android:layout_gravity="center_horizontal"
+                        android:adjustViewBounds="true" />
 
                 </LinearLayout>
 
@@ -73,10 +74,10 @@
 
 
                 <LinearLayout
-                    android:orientation="vertical"
-                    android:layout_marginBottom="15dp"
                     android:layout_width="match_parent"
-                    android:layout_height="wrap_content">
+                    android:layout_height="wrap_content"
+                    android:layout_marginBottom="15dp"
+                    android:orientation="vertical">
 
                     <TextView
                         android:id="@+id/provided_provided_by"
@@ -89,11 +90,11 @@
                         android:textAppearance="@style/AppTheme.TextAppearance.Label" />
 
                     <ImageView
-                        android:adjustViewBounds="true"
-                        android:layout_gravity="center_horizontal"
                         style="@style/AboutSurfIcon"
                         android:layout_width="120dp"
-                        android:layout_height="wrap_content"/>
+                        android:layout_height="wrap_content"
+                        android:layout_gravity="center_horizontal"
+                        android:adjustViewBounds="true" />
 
                 </LinearLayout>
 
@@ -140,6 +141,29 @@
                     android:textAppearance="@style/AppTheme.TextAppearance.Label"
                     app:drawableBottomCompat="@drawable/logo_keen_design" />
             </com.google.android.material.card.MaterialCardView>
+
+            <com.google.android.material.card.MaterialCardView
+                android:id="@+id/security"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_gravity="center_horizontal"
+                android:clickable="true"
+                android:focusable="true"
+                app:cardElevation="6dp">
+
+                <TextView
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:gravity="center_horizontal"
+                    android:text="@string/about_label_security_capabilities"
+                    android:textAppearance="@style/AppTheme.TextAppearance.Label" />
+
+                <TextView
+                    android:id="@+id/security_data"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content" />
+            </com.google.android.material.card.MaterialCardView>
+
         </LinearLayout>
     </androidx.core.widget.NestedScrollView>
 </layout>

--- a/core/src/main/res/values/strings.xml
+++ b/core/src/main/res/values/strings.xml
@@ -54,6 +54,7 @@
     <string name="about_label_provided_by">Provided by:</string>
     <string name="about_label_developed_by">Developed by:</string>
     <string name="about_label_interaction_by">Interaction design:</string>
+    <string name="about_label_security_capabilities">Security capabilities:</string>
 
     <!-- Enroll (Confirm) -->
     <string name="enroll_confirm_title">Confirm account activation</string>

--- a/core/src/main/res/values/strings.xml
+++ b/core/src/main/res/values/strings.xml
@@ -120,4 +120,5 @@
     <!-- Notification channel -->
     <string name="notification_channel_name">Messages</string>
     <string name="notification_channel_description">Notifications for messages from tiqr</string>
+    <string name="about_copied" tools:ignore="ExtraTranslation">Copied</string>
 </resources>


### PR DESCRIPTION
### Short Description of Change
Figure out security capabilities of devices where keystore initialization fails.

### Motivation and Context
There are many situations that can cause a keystore exception. In order to understand why it happens on some devices we need learn what security capabilities these special devices have/don't have.
Towards that end, I propose we list them in the about screen and allow users to easily email them to support
⚠️ Need a correct email address to pre-fill for this.

### Testing Steps
Open about screen. Click on the bottom card. It should open a prefilled email.
Long press on the bottom card in the about screen. It will copy the device security capabilites
### Additional Information

https://user-images.githubusercontent.com/2356050/230365003-a5385687-92a5-46a7-b4a6-e7c92e9b948a.mp4

