### PR TITLE
Fix TIQR-368: only start the camera when app is resumed

### DIFF
--- a/data/build.gradle.kts
+++ b/data/build.gradle.kts
@@ -82,6 +82,7 @@ android {
         implementation(libs.androidx.core)
         implementation(libs.androidx.lifecycle.livedata)
         implementation(libs.androidx.lifecycle.viewmodel)
+        implementation(libs.androidx.lifecycle.scope)
         implementation(libs.google.android.material)
 
         implementation(libs.dagger.hilt.android)

--- a/data/src/main/java/org/tiqr/data/scan/ScanComponent.kt
+++ b/data/src/main/java/org/tiqr/data/scan/ScanComponent.kt
@@ -47,8 +47,10 @@ import androidx.camera.view.PreviewView
 import androidx.concurrent.futures.await
 import androidx.core.content.ContextCompat
 import androidx.lifecycle.DefaultLifecycleObserver
+import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.lifecycleScope
+import androidx.lifecycle.repeatOnLifecycle
 import androidx.localbroadcastmanager.content.LocalBroadcastManager
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
@@ -106,10 +108,11 @@ class ScanComponent(
 
     init {
         lifecycleOwner.lifecycle.addObserver(this)
-
         lifecycleScope.launch {
-            cameraProvider = initCameraProvider()
-            startCamera(cameraProvider)
+            lifecycleOwner.repeatOnLifecycle(Lifecycle.State.RESUMED) {
+                cameraProvider = initCameraProvider()
+                startCamera(cameraProvider)
+            }
         }
     }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,7 +2,7 @@
 android-sdk-compile = "34"
 android-sdk-target = "34"
 android-sdk-min = "24"
-agp = "8.2.0"
+agp = "8.2.1"
 gms = "4.4.0"
 
 kotlin = "1.9.20"
@@ -12,7 +12,7 @@ ksp-plugin = "1.9.20-1.0.14"
 hilt = "2.48.1"
 navigation = "2.7.6"
 room = "2.6.1"
-lifecycle = "2.6.2"
+lifecycle = "2.7.0"
 camera = "1.3.1"
 
 okhttp = "4.12.0"
@@ -51,6 +51,7 @@ androidx-testing-uiautomator = "androidx.test.uiautomator:uiautomator:2.3.0-beta
 androidx-lifecycle-common = { module = "androidx.lifecycle:lifecycle-common-java8", version.ref = "lifecycle" }
 androidx-lifecycle-livedata = { module = "androidx.lifecycle:lifecycle-livedata-ktx", version.ref = "lifecycle" }
 androidx-lifecycle-viewmodel = { module = "androidx.lifecycle:lifecycle-viewmodel-ktx", version.ref = "lifecycle" }
+androidx-lifecycle-scope = { module = "androidx.lifecycle:lifecycle-runtime-ktx", version.ref = "lifecycle" }
 
 androidx-navigation-fragment = { module = "androidx.navigation:navigation-fragment-ktx", version.ref = "navigation" }
 androidx-navigation-ui = { module = "androidx.navigation:navigation-ui-ktx", version.ref = "navigation" }


### PR DESCRIPTION
Use a restartable Lifecycle-aware coroutine for opening the camera to ensure we're not trying to use a view that isn't there yet. Updated some dependencies.