### PR TITLE
TIQR-430: Don't keep the authentication tasks in the list of recent apps

### DIFF
--- a/core/src/main/java/org/tiqr/core/messaging/TiqrMessagingService.kt
+++ b/core/src/main/java/org/tiqr/core/messaging/TiqrMessagingService.kt
@@ -105,7 +105,8 @@ class TiqrMessagingService : FirebaseMessagingService() {
             }
 
             val intent = Intent(Intent.ACTION_VIEW, Uri.parse(challenge)).also { intent ->
-                intent.flags = Intent.FLAG_ACTIVITY_CLEAR_TOP
+                intent.flags =
+                    Intent.FLAG_ACTIVITY_CLEAR_TOP or Intent.FLAG_ACTIVITY_NEW_DOCUMENT or Intent.FLAG_ACTIVITY_EXCLUDE_FROM_RECENTS
             }
             val flags = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
                 PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT

--- a/core/src/main/java/org/tiqr/core/messaging/TiqrMessagingService.kt
+++ b/core/src/main/java/org/tiqr/core/messaging/TiqrMessagingService.kt
@@ -108,11 +108,7 @@ class TiqrMessagingService : FirebaseMessagingService() {
                 intent.flags =
                     Intent.FLAG_ACTIVITY_CLEAR_TOP or Intent.FLAG_ACTIVITY_NEW_DOCUMENT or Intent.FLAG_ACTIVITY_EXCLUDE_FROM_RECENTS
             }
-            val flags = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-                PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT
-            } else {
-                PendingIntent.FLAG_UPDATE_CURRENT
-            }
+            val flags = PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT
 
             NotificationCompat.Builder(this, CHANNEL_ID)
                 .setContentIntent(PendingIntent.getActivity(this, 0, intent, flags))


### PR DESCRIPTION
When handling push notifications for authentication, start the activity with the flag `FLAG_ACTIVITY_EXCLUDE_FROM_RECENTS`. This will make sure that once authentication is completed, the TIQR app will not be found in the list of recent apps again.

This solves the problem for authenticating via push notifications. 
This is not solved if the authentication is started from the mobile browser, page in the browser is responsible for creating the intent & its flags that starts the authentication. AFAICT via this route, the `FLAG_ACTIVITY_EXCLUDE_FROM_RECENTS` is not part of the intent to authenticate.