### PR TITLE
TIQR-500: Crash fixes

### DIFF
--- a/core/src/main/java/org/tiqr/core/scan/ScanFragment.kt
+++ b/core/src/main/java/org/tiqr/core/scan/ScanFragment.kt
@@ -47,6 +47,7 @@ import org.tiqr.data.model.ChallengeParseResult
 import org.tiqr.data.model.EnrollmentChallenge
 import org.tiqr.data.scan.ScanComponent
 import org.tiqr.data.viewmodel.ScanViewModel
+import timber.log.Timber
 
 @AndroidEntryPoint
 class ScanFragment : BaseFragment<FragmentScanBinding>() {
@@ -99,7 +100,14 @@ class ScanFragment : BaseFragment<FragmentScanBinding>() {
                     .setTitle(result.failure.title)
                     .setMessage(result.failure.message)
                     .setCancelable(false)
-                    .setNegativeButton(R.string.button_cancel) { _, _ -> findNavController().popBackStack() }
+                    .setNegativeButton(R.string.button_cancel) { _, _ ->
+                        try {
+                            findNavController().popBackStack()
+                        } catch (ex: IllegalStateException) {
+                            // Fragment is already popped? Ignore.
+                            Timber.w(ex, "Could not pop back stack, nav controller not found.")
+                        }
+                    }
                     .setPositiveButton(R.string.button_retry) { dialog, _ ->
                         dialog.dismiss()
                         scanComponent.resumeScanning()

--- a/data/src/main/java/org/tiqr/data/scan/ScanComponent.kt
+++ b/data/src/main/java/org/tiqr/data/scan/ScanComponent.kt
@@ -36,6 +36,7 @@ import android.media.SoundPool
 import android.os.Build
 import android.os.VibrationEffect
 import android.os.Vibrator
+import android.view.Surface
 import androidx.annotation.CheckResult
 import androidx.camera.core.AspectRatio
 import androidx.camera.core.Camera
@@ -160,7 +161,6 @@ class ScanComponent(
      * Start the camera and QR code detection
      */
     private fun startCamera(cameraProvider: ProcessCameraProvider) {
-
         val rotation = viewFinder.display.rotation
         val metrics = viewFinder.context.resources.displayMetrics
         val screenAspectRatio = aspectRatio(metrics.widthPixels, metrics.heightPixels)

--- a/data/src/main/java/org/tiqr/data/scan/ScanComponent.kt
+++ b/data/src/main/java/org/tiqr/data/scan/ScanComponent.kt
@@ -161,7 +161,7 @@ class ScanComponent(
      * Start the camera and QR code detection
      */
     private fun startCamera(cameraProvider: ProcessCameraProvider) {
-        val rotation = viewFinder.display.rotation
+        val rotation = viewFinder.display?.rotation ?: Surface.ROTATION_0
         val metrics = viewFinder.context.resources.displayMetrics
         val screenAspectRatio = aspectRatio(metrics.widthPixels, metrics.heightPixels)
         cameraPreview = Preview.Builder()


### PR DESCRIPTION
- Fixes a rare crash which happened when the scan component could not determine the orientation of the device. We will use the default orientation in this case.
- Fixes a rare crash which happened when dismissing the incorrect QR code dialog could not dismiss the scan view. In this case we will ignore the issue, since if we either go to the home screen or stay on the scan view, it is still better than the crash