### PR TITLE
TIQR-515: Move in app updates from core to data

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ The following metadata properties are supported:
 * `tiqr_config_enroll_scheme`: The enrollment URL should start with this HTTP scheme. Do not add the :// to the end of it.
 * `tiqr_config_auth_scheme`: The authentication URL should start with this HTTP scheme. Do not add the :// to the end of it.
 * `tiqr_config_token_exchange_enabled`: If the token exchange feature is enabled. When set to false, the FCM token will not be converted, but sent directly to the server.
+* `tiqr_config_in_app_update_check_enabled`: If the application should automatically check for new updates in the Google Play Store. Disabled by default. You can also use InAppUpdatesUtil manually while keeping this disabled.
 
 # Making changes in library
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -35,6 +35,7 @@ android {
         manifestPlaceholders["tiqr_config_enroll_scheme"] = "tiqrenroll"
         manifestPlaceholders["tiqr_config_auth_scheme"] = "tiqrauth"
         manifestPlaceholders["tiqr_config_token_exchange_enabled"] = "false"
+        manifestPlaceholders["tiqr_config_in_app_update_check_enabled"] = "true"
 
         // only package supported languages
         resourceConfigurations += listOf(

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -70,5 +70,6 @@
         <meta-data android:name="tiqr_config_enroll_scheme" android:value="${tiqr_config_enroll_scheme}"/>
         <meta-data android:name="tiqr_config_auth_scheme" android:value="${tiqr_config_auth_scheme}"/>
         <meta-data android:name="tiqr_config_token_exchange_enabled" android:value="${tiqr_config_token_exchange_enabled}"/>
+        <meta-data android:name="tiqr_config_in_app_update_check_enabled" android:value="${tiqr_config_in_app_update_check_enabled}"/>
     </application>
 </manifest>

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -81,7 +81,6 @@ dependencies {
 
     implementation(libs.androidx.activity)
     implementation(libs.androidx.autofill)
-    implementation(libs.androidx.appUpdate)
 
     implementation(libs.androidx.constraintlayout)
     implementation(libs.androidx.core)

--- a/core/src/main/java/org/tiqr/core/MainActivity.kt
+++ b/core/src/main/java/org/tiqr/core/MainActivity.kt
@@ -53,7 +53,7 @@ import kotlinx.coroutines.tasks.await
 import org.tiqr.core.base.BaseActivity
 import org.tiqr.core.databinding.ActivityMainBinding
 import org.tiqr.core.scan.ScanFragment
-import org.tiqr.core.util.InAppUpdatesUtil
+import org.tiqr.data.util.InAppUpdatesUtil
 import org.tiqr.data.scan.ScanKeyEventsReceiver
 import org.tiqr.core.util.extensions.currentNavigationFragment
 import org.tiqr.core.util.extensions.getNavController

--- a/core/src/main/java/org/tiqr/core/MainActivity.kt
+++ b/core/src/main/java/org/tiqr/core/MainActivity.kt
@@ -135,10 +135,10 @@ open class MainActivity : BaseActivity<ActivityMainBinding>(),
                     if (clickTimes % 5 == 0) {
                         if (InAppUpdatesUtil.isTestingEnabled(this@MainActivity)) {
                             InAppUpdatesUtil.setTestingEnabled(this@MainActivity, false)
-                            Toast.makeText(this@MainActivity, R.string.app_update_testing_disabled, Toast.LENGTH_LONG).show()
+                            Toast.makeText(this@MainActivity, org.tiqr.data.R.string.app_update_testing_disabled, Toast.LENGTH_LONG).show()
                         } else {
                             InAppUpdatesUtil.setTestingEnabled(this@MainActivity, true)
-                            Toast.makeText(this@MainActivity, R.string.app_update_testing_enabled, Toast.LENGTH_LONG).show()
+                            Toast.makeText(this@MainActivity, org.tiqr.data.R.string.app_update_testing_enabled, Toast.LENGTH_LONG).show()
                         }
                     }
                 }

--- a/core/src/main/res/values-nl/strings.xml
+++ b/core/src/main/res/values-nl/strings.xml
@@ -112,8 +112,6 @@
     <string name="button_allow">Sta toe</string>
     <string name="button_deny">Weiger</string>
 
-    <string name="app_update_popup_message">App update is gereed om te installeren</string>
-    <string name="app_update_popup_button">Installeer</string>
     <string name="app_update_testing_enabled">In-app update testing ingeschakeld</string>
     <string name="app_update_testing_disabled">In-app update testing uitgeschakeld</string>
 </resources>

--- a/core/src/main/res/values/strings.xml
+++ b/core/src/main/res/values/strings.xml
@@ -117,9 +117,4 @@ a
     <!-- Notification channel -->
     <string name="notification_channel_description">Notifications for messages from tiqr</string>
     <string name="about_copied" tools:ignore="ExtraTranslation">Copied</string>
-    
-    <string name="app_update_popup_message">App update is ready to install</string>
-    <string name="app_update_popup_button">Install</string>
-    <string name="app_update_testing_enabled">In-app update testing has been enabled</string>
-    <string name="app_update_testing_disabled">In-app update testing has been disabled</string>
 </resources>

--- a/data/build.gradle.kts
+++ b/data/build.gradle.kts
@@ -83,7 +83,9 @@ android {
         implementation(libs.androidx.lifecycle.livedata)
         implementation(libs.androidx.lifecycle.viewmodel)
         implementation(libs.androidx.lifecycle.scope)
+        implementation(libs.androidx.appUpdate)
         implementation(libs.google.android.material)
+
 
         implementation(libs.dagger.hilt.android)
         ksp(libs.dagger.hilt.compiler)

--- a/data/src/main/java/org/tiqr/data/util/InAppUpdatesUtil.kt
+++ b/data/src/main/java/org/tiqr/data/util/InAppUpdatesUtil.kt
@@ -1,8 +1,9 @@
-package org.tiqr.core.util
+package org.tiqr.data.util
 
 import android.app.Activity
 import android.app.Activity.RESULT_CANCELED
 import android.app.Activity.RESULT_OK
+import android.content.Context
 import androidx.activity.ComponentActivity
 import androidx.activity.result.ActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
@@ -14,7 +15,7 @@ import com.google.android.play.core.install.InstallStateUpdatedListener
 import com.google.android.play.core.install.model.AppUpdateType
 import com.google.android.play.core.install.model.InstallStatus
 import com.google.android.play.core.install.model.UpdateAvailability
-import org.tiqr.core.R
+import org.tiqr.data.R
 import timber.log.Timber
 
 object InAppUpdatesUtil {
@@ -105,13 +106,13 @@ object InAppUpdatesUtil {
         }
     }
 
-    fun isTestingEnabled(activity: ComponentActivity): Boolean {
-        val preferences = activity.getSharedPreferences(PREFERENCES_NAME, Activity.MODE_PRIVATE)
+    fun isTestingEnabled(context: Context): Boolean {
+        val preferences = context.getSharedPreferences(PREFERENCES_NAME, Activity.MODE_PRIVATE)
         return preferences.getBoolean(KEY_TESTING_ENABLED, false)
     }
 
-    fun setTestingEnabled(activity: ComponentActivity, enabled: Boolean) {
-        val preferences = activity.getSharedPreferences(PREFERENCES_NAME, Activity.MODE_PRIVATE)
+    fun setTestingEnabled(context: Context, enabled: Boolean) {
+        val preferences = context.getSharedPreferences(PREFERENCES_NAME, Activity.MODE_PRIVATE)
         preferences.edit().putBoolean(KEY_TESTING_ENABLED, enabled).apply()
     }
 }

--- a/data/src/main/res/values-nl/strings.xml
+++ b/data/src/main/res/values-nl/strings.xml
@@ -60,4 +60,6 @@
     <string name="auth_pin_subtitle">Vul de PIN in en druk op OK:</string>
     <string name="notification_channel_name">Berichten</string>
 
+    <string name="app_update_popup_message">App update is gereed om te installeren</string>
+    <string name="app_update_popup_button">Installeer</string>
 </resources>

--- a/data/src/main/res/values/strings.xml
+++ b/data/src/main/res/values/strings.xml
@@ -71,4 +71,9 @@
 
     <string name="auth_pin_subtitle">Enter the PIN and press OK:</string>
     <string name="notification_channel_name">Messages</string>
+    
+    <string name="app_update_popup_message">App update is ready to install</string>
+    <string name="app_update_popup_button">Install</string>
+    <string name="app_update_testing_enabled">In-app update testing has been enabled</string>
+    <string name="app_update_testing_disabled">In-app update testing has been disabled</string>
 </resources>

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,12 +2,12 @@
 android-sdk-compile = "34"
 android-sdk-target = "34"
 android-sdk-min = "24"
-agp = "8.2.1"
+agp = "8.8.2"
 gms = "4.4.0"
 
-kotlin = "1.9.20"
+kotlin = "1.9.25"
 coroutines = "1.7.3"
-ksp-plugin = "1.9.20-1.0.14"
+ksp-plugin = "1.9.25-1.0.20"
 
 hilt = "2.48.1"
 navigation = "2.7.6"

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Fri Nov 17 16:13:21 CET 2023
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.13-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
eduID only imports `data`, so this is a better fit.
Also changed some parameters from `activity` to `context` so it is more usable in Compose