### PR TITLE
TIQR-571: Fix navigation not working when the user needs to enter system PIN

### DIFF
--- a/core/src/main/java/org/tiqr/core/authentication/AuthenticationBiometricFragment.kt
+++ b/core/src/main/java/org/tiqr/core/authentication/AuthenticationBiometricFragment.kt
@@ -44,6 +44,7 @@ import org.tiqr.data.model.ChallengeCompleteResult
 import org.tiqr.data.model.SecretCredential
 import org.tiqr.data.model.SecretType
 import org.tiqr.data.viewmodel.AuthenticationViewModel
+import timber.log.Timber
 
 @AndroidEntryPoint
 class AuthenticationBiometricFragment : BaseFragment<FragmentAuthenticationBiometricBinding>() {
@@ -54,7 +55,13 @@ class AuthenticationBiometricFragment : BaseFragment<FragmentAuthenticationBiome
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-
+        viewModel.navigateToFallbackWhenResumed.observe(viewLifecycleOwner) { navigate ->
+            if (navigate) {
+                Timber.i("Navigating to fallback PIN authentication")
+                goToFallback()
+                viewModel.navigateToFallbackWhenResumed.value = false
+            }
+        }
         viewModel.authenticate.observe(viewLifecycleOwner) { it ->
             binding.progress.hide()
 
@@ -121,12 +128,12 @@ class AuthenticationBiometricFragment : BaseFragment<FragmentAuthenticationBiome
                 )
                 is AuthenticationBiometricComponent.BiometricResult.Cancel -> {
                     binding.progress.hide()
-                    viewModel.challenge.value?.let { challenge ->
-                        findNavController().navigate(
-                            AuthenticationBiometricFragmentDirections.actionPin(
-                                challenge
-                            )
-                        )
+                    val fragmentManager = activity?.supportFragmentManager
+                    if (fragmentManager?.isStateSaved == true) {
+                        Timber.i("Navigating to fallback PIN authentication not possible because the state is already saved, deferring to onResume")
+                        viewModel.navigateToFallbackWhenResumed.value = true
+                    } else {
+                        goToFallback()
                     }
                 }
                 is AuthenticationBiometricComponent.BiometricResult.Fail -> {
@@ -138,6 +145,16 @@ class AuthenticationBiometricFragment : BaseFragment<FragmentAuthenticationBiome
         }.run {
             binding.progress.show()
             authenticate()
+        }
+    }
+
+    private fun goToFallback() {
+        viewModel.challenge.value?.let { challenge ->
+            findNavController().navigate(
+                AuthenticationBiometricFragmentDirections.actionPin(
+                    challenge
+                )
+            )
         }
     }
 }

--- a/data/src/main/java/org/tiqr/data/viewmodel/AuthenticationViewModel.kt
+++ b/data/src/main/java/org/tiqr/data/viewmodel/AuthenticationViewModel.kt
@@ -57,6 +57,7 @@ class AuthenticationViewModel @Inject constructor(
             emit(repository.completeChallenge(it))
         }
     }
+    val navigateToFallbackWhenResumed = MutableLiveData(false)
 
     private val _otpGenerate = MutableLiveData<SecretCredential>()
     val otp = _otpGenerate.switchMap { credential ->


### PR DESCRIPTION
Since the fragment manager state was already saved, it was ignoring any navigate() calls. Now we detect this, and defer it to when the app comes back from the background.