### PR TITLE
TIQR-573: Fix configuration change issue with push notifications

### DIFF
--- a/core/src/main/java/org/tiqr/core/MainActivity.kt
+++ b/core/src/main/java/org/tiqr/core/MainActivity.kt
@@ -96,6 +96,10 @@ open class MainActivity : BaseActivity<ActivityMainBinding>(),
         }
         mainViewModel.executeTokenMigrationIfNeeded { getDeviceToken() }
         mainViewModel.challenge.observe(this) { result ->
+            if (mainViewModel.didHandleChallenge.value == true) {
+                // Already handled, probably due to configuration change
+                return@observe
+            }
             when (result) {
                 is ChallengeParseResult.Success -> {
                     when (result.value) {
@@ -126,6 +130,7 @@ open class MainActivity : BaseActivity<ActivityMainBinding>(),
                         .show()
                 }
             }
+            mainViewModel.didHandleChallenge.value = true
         }
         if (TiqrConfig.inAppUpdateCheckEnabled) {
             InAppUpdatesUtil.checkForUpdates(this)

--- a/data/src/main/java/org/tiqr/data/viewmodel/MainViewModel.kt
+++ b/data/src/main/java/org/tiqr/data/viewmodel/MainViewModel.kt
@@ -53,6 +53,7 @@ class MainViewModel @Inject constructor(
 ) : ViewModel() {
 
     private val rawChallengeObserver = MutableLiveData<String>()
+    val didHandleChallenge = MutableLiveData<Boolean>()
     val challenge = rawChallengeObserver.switchMap { rawChallenge ->
         liveData {
             when {
@@ -69,6 +70,7 @@ class MainViewModel @Inject constructor(
      * Parse the [rawChallenge]
      */
     fun parseChallenge(rawChallenge: String) {
+        didHandleChallenge.value = false
         rawChallengeObserver.value = rawChallenge
     }
 


### PR DESCRIPTION
In some cases, rotating the screen added an extra authentication confirmation fragment.
This PR fixes that by adding an extra check in the viewmodel if we already handled it.